### PR TITLE
feat: allow sso authentication on teams

### DIFF
--- a/assets/iframe.html
+++ b/assets/iframe.html
@@ -32,8 +32,8 @@
           isExternal: false,
         })
         .then(microsoftTeams.authentication.getAuthToken)
-        .then(updateUserWithTeamsToken)
-        .then(refreshIframe)
+        .then(microsoftTeams.app.getContext)
+        .then(redirectToUserSetupPage)
         .catch(function (e) {
           console.error("Authentication failed:", e);
         });
@@ -44,20 +44,17 @@
       return microsoftTeams.app.notifySuccess();
     }
 
-    function updateUserWithTeamsToken(token) {
-      // Get current user from the MMUSERID cookie
-      const mmUserId = document.cookie.split('; ').find(row => row.startsWith('MMUSERID=')).split('=')[1];
-
+    function updateUserWithTeamsContext(context) {
       // Update current Mattermost user with the token
-      return fetch(`/plugins/com.mattermost.plugin-msteams-devsecops/users/login`, {
+      return fetch(`/plugins/com.mattermost.plugin-msteams-devsecops/users/setup`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          user_id: mmUserId,
-          teams_token: token,
-        })
+          user_id: context.user.id,
+          user_principal_name: context.user.userPrincipalName,
+        })      
       }).then(function (response) {
         console.log("User updated successfully");
         return response;
@@ -66,9 +63,10 @@
       });
     }
 
-    function refreshIframe() {
+    // Redirect to the user setup page where we will store the user information and redirect back to the Mattermost login page
+    function redirectToUserSetupPage(context) {
       iframe = document.querySelector('iframe');
-      iframe.src = "{{SITE_URL}}?_t=" + new Date().getTime();
+      iframe.src = "{{SITE_URL}}/plugins/com.mattermost.plugin-msteams-devsecops/users/setup?id=" + context.user.id + "&user_principal_name=" + context.user.userPrincipalName + "&_t=" + new Date().getTime();
     }
   </script>
 </body>

--- a/assets/iframe.html
+++ b/assets/iframe.html
@@ -1,23 +1,76 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <title>Mattermost DevSecOps</title>
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0">
-  <script src="https://statics.teams.cdn.office.net/sdk/v1.10.0/js/MicrosoftTeams.min.js"></script>
+  <script src="https://res.cdn.office.net/teams-js/2.34.0/js/MicrosoftTeams.min.js"
+    integrity="sha384-brW9AazbKR2dYw2DucGgWCCcmrm2oBFV4HQidyuyZRI/TnAkmOOnTARSTdps3Hwt"
+    crossorigin="anonymous"></script>
 </head>
+
 <body>
-    <iframe
-        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;"
-        src="{{SITE_URL}}" title="Mattermost DevSecOps" onload="notifyAppLoaded()">
-    </iframe>
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;" src="{{SITE_URL}}"
+    title="Mattermost DevSecOps" onload="notifyAppLoaded()">
+  </iframe>
   <script>
     // Initialize the Microsoft Teams SDK
-    microsoftTeams.initialize();
+    microsoftTeams.app.initialize(["{{SITE_URL}}"]);
+
+    // Listen for a message from the iframe "mattermost_external_auth_login" sent by using `window.parent.postMessage`
+    window.addEventListener('message', async function (event) {
+      console.log('Received message from Mattermost:', event.data);
+
+      if (event.data.type === 'mattermost_external_auth_login') {
+        console.log("Authenticating...");
+
+        microsoftTeams.authentication.authenticate({
+          url: event.data.href,
+          width: 600,
+          height: 535,
+          isExternal: false,
+        })
+        .then(microsoftTeams.authentication.getAuthToken)
+        .then(updateUserWithTeamsToken)
+        .then(refreshIframe)
+        .catch(function (e) {
+          console.error("Authentication failed:", e);
+        });
+      }
+    });
 
     function notifyAppLoaded() {
-      microsoftTeams.appInitialization.notifySuccess();
+      return microsoftTeams.app.notifySuccess();
+    }
+
+    function updateUserWithTeamsToken(token) {
+      // Get current user from the MMUSERID cookie
+      const mmUserId = document.cookie.split('; ').find(row => row.startsWith('MMUSERID=')).split('=')[1];
+
+      // Update current Mattermost user with the token
+      return fetch(`/plugins/com.mattermost.plugin-msteams-devsecops/users/login`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          user_id: mmUserId,
+          teams_token: token,
+        })
+      }).then(function (response) {
+        console.log("User updated successfully");
+        return response;
+      }).catch(function (error) {
+        return "Error updating user: " + error;
+      });
+    }
+
+    function refreshIframe() {
+      iframe = document.querySelector('iframe');
+      iframe.src = "{{SITE_URL}}?_t=" + new Date().getTime();
     }
   </script>
 </body>
+
 </html>


### PR DESCRIPTION
#### Summary

Allows SSO authentication on teams by providing:
- An endpoint to store the teams user token
- Iframe now reacts to the `mattermost_external_auth_login` message and triggers the teams login flow (coming from https://github.com/mattermost/mattermost/pull/30408)

#### Ticket Link

