### PR TITLE
Microphone support (for Calls plugin)

### DIFF
--- a/assets/appmanifest.json.tmpl
+++ b/assets/appmanifest.json.tmpl
@@ -60,6 +60,9 @@
             ]
         }
     },
+    "devicePermissions": [
+        "media"
+    ],    
     "defaultGroupCapability": {
         "team": "tab"
     },

--- a/assets/iframe.html.tmpl
+++ b/assets/iframe.html.tmpl
@@ -15,7 +15,6 @@
     <iframe
         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;"
         title="Mattermost DevSecOps"
-        allow="microphone; display-capture"
         src="about:blank">
     </iframe>
   <script>

--- a/assets/iframe.html.tmpl
+++ b/assets/iframe.html.tmpl
@@ -15,7 +15,7 @@
     <iframe
         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;"
         title="Mattermost DevSecOps"
-        allow="camera; microphone; display-capture; autoplay; clipboard-write"
+        allow="microphone; display-capture"
         src="about:blank">
     </iframe>
   <script>

--- a/assets/iframe.html.tmpl
+++ b/assets/iframe.html.tmpl
@@ -15,6 +15,7 @@
     <iframe
         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;"
         title="Mattermost DevSecOps"
+        allow="camera; microphone; display-capture; autoplay; clipboard-write"
         src="about:blank">
     </iframe>
   <script>

--- a/assets/iframe_notification_preview.html.tmpl
+++ b/assets/iframe_notification_preview.html.tmpl
@@ -38,7 +38,7 @@
             background-color: var(--color-background);
         }
         .notification-container {
-            max-width: 600px;
+            max-width: 1200px;
             margin: 0 auto;
             background-color: var(--color-white);
             border-radius: 4px;
@@ -126,8 +126,7 @@
         }
 
         /* Markdown styles */
-         /* Markdown styles */
-         .message-content h1, .message-content h2, .message-content h3,
+        .message-content h1, .message-content h2, .message-content h3,
         .message-content h4, .message-content h5, .message-content h6 {
             margin-top: 16px;
             margin-bottom: 8px;
@@ -229,7 +228,7 @@
 
     <div class="notification-container">
         <div class="notification-header">
-            {{.NotificationPreviewContext.PostAuthorDisplay}} mentioned you in Mattermost
+            {{.NotificationPreviewContext.PostAuthorDisplay}} {{.NotificationPreviewContext.Action}} in Mattermost
         </div>
         <div class="notification-content">
             <div class="message-header">

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -71,8 +71,8 @@ func (a *API) iFrame(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 	w.Header().Set("Content-Type", "text/html")
 
-	// Set permissions policy for camera and microphone access within the iFrame
-	perms := fmt.Sprintf(`camera=(self "%s"), microphone=(self "%s")`, iframeCtx.SiteURL, iframeCtx.SiteURL)
+	// Set permissions policy for microphone and display-catpure access within the iFrame (for Calls plugin)
+	perms := fmt.Sprintf(`microphone=(self "%s"), display-capture=(self "%s")`, iframeCtx.SiteURL, iframeCtx.SiteURL)
 	w.Header().Set("Permissions-Policy", perms)
 
 	// set session cookie to indicate Mattermost is hosted in an iFrame, which allows

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -41,6 +41,7 @@ type iFrameNotificationPreviewContext struct {
 	ChannelNameDisplay   string
 	PostAuthorDisplay    string
 	PostCreatedAtDisplay string
+	Action               string
 }
 
 // iFrame returns the iFrame HTML needed to host Mattermost within a MS Teams app.
@@ -169,8 +170,14 @@ func (a *API) createIFrameContext(userID string, post *model.Post) (iFrameContex
 	}
 
 	channelDisplayName := channel.Name
-	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
-		iFrameCtx.NotificationPreviewContext.ChannelNameDisplay = "Direct Message"
+	action := "mentioned you"
+	switch channel.Type {
+	case model.ChannelTypeDirect:
+		channelDisplayName = "Direct Message"
+		action = "sent you a direct message"
+	case model.ChannelTypeGroup:
+		channelDisplayName = "Group Message"
+		action = "sent you a group message"
 	}
 
 	iFrameCtx.NotificationPreviewContext = iFrameNotificationPreviewContext{
@@ -179,6 +186,7 @@ func (a *API) createIFrameContext(userID string, post *model.Post) (iFrameContex
 		ChannelNameDisplay:   channelDisplayName,
 		PostAuthorDisplay:    author.GetDisplayName(model.ShowNicknameFullName),
 		PostCreatedAtDisplay: time.Unix(post.CreateAt/1000, 0).Format("January 2, 2006 • 03:04 PM"), // Format date in this way: "April 4, 2025 • 10:43 AM"
+		Action:               action,
 	}
 
 	return iFrameCtx, nil

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -71,10 +71,6 @@ func (a *API) iFrame(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 	w.Header().Set("Content-Type", "text/html")
 
-	// Set permissions policy for microphone and display-catpure access within the iFrame (for Calls plugin)
-	perms := fmt.Sprintf(`microphone=(self "%s"), display-capture=(self "%s")`, iframeCtx.SiteURL, iframeCtx.SiteURL)
-	w.Header().Set("Permissions-Policy", perms)
-
 	// set session cookie to indicate Mattermost is hosted in an iFrame, which allows
 	// webapp to bypass "Where do you want to view this" page and set SameSite=none.
 	http.SetCookie(w, &http.Cookie{

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -164,6 +164,11 @@ func (p *NotificationsParser) sendUserNotification(un *UserNotification) error {
 		return nil
 	}
 
+	// don't send notifications to bots
+	if un.User.IsBot {
+		return nil
+	}
+
 	channelMembership, err := p.PAPI.GetChannelMember(un.Post.ChannelId, un.User.Id)
 	if err != nil {
 		return err
@@ -187,6 +192,11 @@ func (p *NotificationsParser) sendGroupNotification(un *UserNotification) error 
 	for _, user := range userGroup {
 		// Avoid sending notifications to the user who posted the message even if it's part of the group
 		if user.Id == un.Post.UserId {
+			continue
+		}
+
+		// don't send notifications to bots
+		if user.IsBot {
 			continue
 		}
 
@@ -234,6 +244,11 @@ func (p *NotificationsParser) sendChannelNotification(un *UserNotification, onli
 		user, err := p.PAPI.GetUser(member.UserId)
 		if err != nil {
 			return err
+		}
+
+		// don't send notifications to bots
+		if user.IsBot {
+			continue
 		}
 
 		users = append(users, user)

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -98,7 +98,7 @@ func (p *NotificationsParser) ProcessPost(post *model.Post) error {
 	}
 
 	for _, notification := range p.Notifications {
-		p.PAPI.LogDebug("Processed mention", "notification", *notification)
+		p.PAPI.LogDebug("Processed mention", "post_id", notification.Post.Id, "channel_id", notification.Post.ChannelId)
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary
Ensure permissions are set for allowing access to microphone so Calls can be used.  App manifests generated by the plugin will have the permissions set in the manifest.  Also, feedback from Matt regarding notification previews was addressed.

**Note:** requires Chrome or Edge (does not work in Firefox)

To allow the microphone in MS Teams, users must also explicitly enable via app settings. See below.  

![calls-perms](https://github.com/user-attachments/assets/7f94671e-50d7-4af3-93eb-a539cc74ddba)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63565
