### PR TITLE
Auto populate frame ancestors on start up

### DIFF
--- a/server/credentials.go
+++ b/server/credentials.go
@@ -64,6 +64,11 @@ func getExpectedPermissions() []expectedPermission {
 }
 
 func (p *Plugin) checkCredentials() {
+	if p.disableCheckCredentials {
+		p.API.LogDebug("Skipping credentials check: check is disabled")
+		return
+	}
+
 	defer func() {
 		if r := recover(); r != nil {
 			p.API.LogError("Recovering from panic", "panic", r, "stack", string(debug.Stack()))

--- a/server/helper_test.go
+++ b/server/helper_test.go
@@ -34,7 +34,8 @@ func setupTestHelper(t *testing.T) *testHelper {
 
 	p := &Plugin{
 		// These mocks are replaced later, but serve the plugin during early initialization
-		msteamsAppClient: &mocks.Client{},
+		msteamsAppClient:        &mocks.Client{},
+		disableCheckCredentials: true,
 	}
 	th := &testHelper{
 		p: p,

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +21,7 @@ import (
 const (
 	pluginID                = "com.mattermost.plugin-msteams-devsecops"
 	checkCredentialsJobName = "check_credentials" //#nosec G101 -- This is a false positive
+	allowedFrameAncestors   = "*.cloud.microsoft teams.microsoft.com *.teams.microsoft.com *.microsoft365.com *.office.com outlook.office.com outlook.office365.com outlook-sdf.office.com outlook-sdf.office365.com"
 )
 
 // Plugin implements the interface expected by the Mattermost server to communicate between the server and plugin processes.
@@ -51,7 +54,8 @@ type Plugin struct {
 	cancelKeyFuncLock sync.Mutex
 
 	// checkCredentialsJob is a job that periodically checks credentials and permissions against the MS Graph API
-	checkCredentialsJob *cluster.Job
+	checkCredentialsJob     *cluster.Job
+	disableCheckCredentials bool
 
 	// clientReconnectCtx and clientReconnectCancel are used to control the client reconnection goroutine
 	clientReconnectCtx    context.Context
@@ -79,12 +83,82 @@ func (p *Plugin) OnActivate() error {
 		return errors.New("this plugin requires an enterprise license")
 	}
 
+	// Update frame ancestors configuration
+	if err := p.updateFrameAncestors(); err != nil {
+		p.API.LogWarn("Failed to update frame ancestors", "error", err.Error())
+		// Continue activation even if this fails
+	}
+
 	p.apiHandler = NewAPI(p)
 
 	p.pluginStore = pluginstore.NewPluginStore(p.API)
 
 	go p.start(false)
 
+	return nil
+}
+
+// updateFrameAncestors updates the ServiceSettings.FrameAncestors configuration
+// to include domains required by this plugin while preserving existing values.
+func (p *Plugin) updateFrameAncestors() error {
+	p.API.LogDebug("Updating frame ancestors configuration")
+
+	// Get the current Mattermost configuration
+	config := p.client.Configuration.GetConfig()
+	if config == nil {
+		return errors.New("failed to get Mattermost configuration")
+	}
+
+	// Get the current frame ancestors as a space-separated string
+	currentAncestorsStr := ""
+	if config.ServiceSettings.FrameAncestors != nil {
+		currentAncestorsStr = *config.ServiceSettings.FrameAncestors
+	}
+
+	// Split the current ancestors into a slice
+	var currentAncestors []string
+	if currentAncestorsStr != "" {
+		currentAncestors = strings.Fields(currentAncestorsStr)
+	}
+
+	// Parse the allowed frame ancestors from our constant
+	allowedDomains := strings.Fields(allowedFrameAncestors)
+
+	// Create a map to track unique domains and preserve existing ones
+	uniqueDomains := make(map[string]bool)
+
+	// Add existing domains to the map
+	for _, domain := range currentAncestors {
+		uniqueDomains[domain] = true
+	}
+
+	// Add our allowed domains to the map
+	for _, domain := range allowedDomains {
+		uniqueDomains[domain] = true
+	}
+
+	// Convert the map back to a slice
+	newAncestors := make([]string, 0, len(uniqueDomains))
+	for domain := range uniqueDomains {
+		newAncestors = append(newAncestors, domain)
+	}
+
+	// Sort the slice alphabetically
+	sort.Strings(newAncestors)
+
+	// Join the slice into a space-separated string
+	newAncestorsStr := strings.Join(newAncestors, " ")
+
+	// Update the configuration
+	config.ServiceSettings.FrameAncestors = &newAncestorsStr
+
+	// Save the updated configuration
+	err := p.client.Configuration.SaveConfig(config)
+	if err != nil {
+		return errors.New("failed to save updated frame ancestors configuration: " + err.Error())
+	}
+
+	p.API.LogInfo("Successfully updated frame ancestors configuration", "ancestors", newAncestorsStr)
 	return nil
 }
 

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -4,10 +4,12 @@
 package main
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
@@ -113,6 +115,94 @@ func TestGetRelativeURL(t *testing.T) {
 
 			actual := getRelativeURL(config)
 			assert.Equal(t, testCase.Expected, actual)
+		})
+	}
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}
+
+func TestUpdateFrameAncestors(t *testing.T) {
+	th := setupTestHelper(t)
+
+	tests := []struct {
+		name             string
+		initialAncestors *string
+		expectedDomains  []string
+		shouldContainAll bool
+	}{
+		{
+			name:             "Empty initial ancestors",
+			initialAncestors: nil,
+			expectedDomains: []string{
+				"*.cloud.microsoft", "*.microsoft365.com", "*.office.com",
+				"*.teams.microsoft.com", "outlook-sdf.office.com",
+				"outlook-sdf.office365.com", "outlook.office.com",
+				"outlook.office365.com", "teams.microsoft.com",
+			},
+			shouldContainAll: true,
+		},
+		{
+			name:             "With existing ancestors",
+			initialAncestors: stringPtr("example.com test.com"),
+			expectedDomains: []string{
+				"example.com", "test.com", "*.cloud.microsoft",
+				"*.microsoft365.com", "*.office.com", "*.teams.microsoft.com",
+			},
+			shouldContainAll: true,
+		},
+		{
+			name:             "With duplicate ancestors",
+			initialAncestors: stringPtr("teams.microsoft.com example.com"),
+			expectedDomains:  []string{"teams.microsoft.com", "example.com"},
+			shouldContainAll: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Get the current config
+			config := th.p.client.Configuration.GetConfig()
+			require.NotNil(t, config)
+
+			// Set the initial frame ancestors
+			config.ServiceSettings.FrameAncestors = tt.initialAncestors
+			err := th.p.client.Configuration.SaveConfig(config)
+			require.NoError(t, err)
+
+			// Call the function
+			err = th.p.updateFrameAncestors()
+			require.NoError(t, err)
+
+			// Get the updated config
+			updatedConfig := th.p.client.Configuration.GetConfig()
+			require.NotNil(t, updatedConfig)
+			require.NotNil(t, updatedConfig.ServiceSettings.FrameAncestors)
+
+			// Check that the frame ancestors contain all expected domains
+			frameAncestors := *updatedConfig.ServiceSettings.FrameAncestors
+			ancestorsList := strings.Fields(frameAncestors)
+
+			if tt.shouldContainAll {
+				for _, domain := range tt.expectedDomains {
+					assert.Contains(t, ancestorsList, domain)
+				}
+			}
+
+			// Check that the list is sorted
+			sortedList := make([]string, len(ancestorsList))
+			copy(sortedList, ancestorsList)
+			sort.Strings(sortedList)
+			assert.Equal(t, sortedList, ancestorsList, "Frame ancestors should be sorted alphabetically")
+
+			// Verify no duplicates
+			uniqueDomains := make(map[string]bool)
+			for _, domain := range ancestorsList {
+				uniqueDomains[domain] = true
+			}
+			assert.Equal(t, len(uniqueDomains), len(ancestorsList), "Frame ancestors should have no duplicates")
 		})
 	}
 }


### PR DESCRIPTION
#### Summary
This PR ensures that the required frame ancestor domains are added to the `ServiceSettings.FrameAncestors` config. Any existing domains are preserved while eliminating duplicates.

#### Ticket Link
NONE