### PR TITLE
IIFE / CSP

### DIFF
--- a/assets/iframe.html.tmpl
+++ b/assets/iframe.html.tmpl
@@ -12,12 +12,21 @@
   ></script>
 </head>
 <body>
+    <style nonce="{{.Nonce}}">
+        iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+    </style>
     <iframe
-        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;"
         title="Mattermost DevSecOps"
         src="about:blank">
     </iframe>
-  <script>
+  <script nonce="{{.Nonce}}">
     (function(microsoftTeams) {
       var iframe = document.querySelector('iframe');
 

--- a/assets/iframe.html.tmpl
+++ b/assets/iframe.html.tmpl
@@ -18,59 +18,60 @@
         src="about:blank">
     </iframe>
   <script>
-    var iframe = document.querySelector('iframe');
+    (function(microsoftTeams) {
+      var iframe = document.querySelector('iframe');
 
-    // Initialize the Microsoft Teams SDK
-    microsoftTeams.app.initialize(['{{.SiteURL}}']).then(() => {
-      microsoftTeams.app.notifySuccess();
-    }).catch((error) => {
-      console.error('Failed to initialize Microsoft Teams SDK:', error);
-    });
+      // Initialize the Microsoft Teams SDK
+      microsoftTeams.app.initialize(['{{.SiteURL}}']).then(() => {
+        microsoftTeams.app.notifySuccess();
+      }).catch((error) => {
+        console.error('Failed to initialize Microsoft Teams SDK:', error);
+      });
 
-    const expectedTenantId = '{{.TenantID}}';
-    const domainRoot = '{{.SiteURL}}';
+      const expectedTenantId = '{{.TenantID}}';
+      const domainRoot = '{{.SiteURL}}';
 
-    // Choose the iFrame content based on the tenant.
-    microsoftTeams.app.getContext().then((context) => {
-      let tenantId;
-      if (context && context.user && context.user.tenant && context.user.tenant.id) {
-        tenantId = context.user.tenant.id;
-      }
-
-      // If the expected tenant matches the actual tenant then try to get auth token
-      if (tenantId === expectedTenantId) {
-        // Build query params to be sent to the iframe.
-        const params = new URLSearchParams()
-        params.set('app_id', context.app.appId.appIdAsString);
-  
-        // Extract the subPageId (subEntityId coming from the Microsoft Teams SDK User Activity notification)
-        // and send it to the iframe to redirect the user to what triggered the notification.
-        if (context && context.page && context.page.subPageId) {
-          params.set('sub_entity_id', context.page.subPageId);
-
+      // Choose the iFrame content based on the tenant.
+      microsoftTeams.app.getContext().then((context) => {
+        let tenantId;
+        if (context && context.user && context.user.tenant && context.user.tenant.id) {
+          tenantId = context.user.tenant.id;
         }
 
-        microsoftTeams.authentication.getAuthToken()
-          .then((token) => {
-            params.set('token', token);
-            iframe.src = `${domainRoot}/plugins/{{.PluginID}}/iframe/authenticate?${params.toString()}`;
-          })
-          .catch((error) => {
-            console.error('Failed to get auth token:', error);
-            iframe.src = domainRoot;
-          });
-      } else {
-        // Expected tenant does not match actual tenant the user is logged into; just redirect to SITE_URL and the user
-        // will have to log in without SSO
-        console.log('No tenant match found, redirecting to default site');
+        // If the expected tenant matches the actual tenant then try to get auth token
+        if (tenantId === expectedTenantId) {
+          // Build query params to be sent to the iframe.
+          const params = new URLSearchParams()
+          params.set('app_id', context.app.appId.appIdAsString);
+    
+          // Extract the subPageId (subEntityId coming from the Microsoft Teams SDK User Activity notification)
+          // and send it to the iframe to redirect the user to what triggered the notification.
+          if (context && context.page && context.page.subPageId) {
+            params.set('sub_entity_id', context.page.subPageId);
+          }
+
+          microsoftTeams.authentication.getAuthToken()
+            .then((token) => {
+              params.set('token', token);
+              iframe.src = `${domainRoot}/plugins/{{.PluginID}}/iframe/authenticate?${params.toString()}`;
+            })
+            .catch((error) => {
+              console.error('Failed to get auth token:', error);
+              iframe.src = domainRoot;
+            });
+        } else {
+          // Expected tenant does not match actual tenant the user is logged into; just redirect to SITE_URL and the user
+          // will have to log in without SSO
+          console.log('No tenant match found, redirecting to default site');
+          iframe.src = '{{.SiteURL}}';
+        }
+      }).catch((error) => {
+        // User appears to not be logged into Microsoft Teams, or the context is not available.
+        // Just redirect to the SITE_URL and the user will have to log in without SSO.
+        console.error('Failed to get context:', error);
         iframe.src = '{{.SiteURL}}';
-      }
-    }).catch((error) => {
-      // User appears to not be logged into Microsoft Teams, or the context is not available.
-      // Just redirect to the SITE_URL and the user will have to log in without SSO.
-      console.error('Failed to get context:', error);
-      iframe.src = '{{.SiteURL}}';
-    });
+      });
+    })(microsoftTeams);
   </script>
 </body>
 </html>

--- a/plugin.json
+++ b/plugin.json
@@ -8,7 +8,6 @@
     "min_server_version": "6.2.1",
     "server": {
         "executables": {
-            "darwin-arm64": "server/dist/plugin-darwin-arm64",
             "linux-amd64": "server/dist/plugin-linux-amd64",
             "linux-arm64": "server/dist/plugin-linux-arm64"
         }

--- a/plugin.json
+++ b/plugin.json
@@ -8,6 +8,7 @@
     "min_server_version": "6.2.1",
     "server": {
         "executables": {
+            "darwin-arm64": "server/dist/plugin-darwin-arm64",
             "linux-amd64": "server/dist/plugin-linux-amd64",
             "linux-arm64": "server/dist/plugin-linux-arm64"
         }

--- a/server/api.go
+++ b/server/api.go
@@ -25,10 +25,10 @@ func NewAPI(p *Plugin) *API {
 	api.handleStaticFiles(router)
 
 	// iFrame support
-	router.HandleFunc("/iframe/mattermostTab", api.iFrame).Methods("GET")
-	router.HandleFunc("/iframe/authenticate", api.authenticate).Methods("GET")
-	router.HandleFunc("/iframe/notification_preview", api.iframeNotificationPreview).Methods("GET")
-	router.HandleFunc("/iframe-manifest", api.appManifest).Methods("GET")
+	router.HandleFunc("/iframe/mattermostTab", api.iFrame).Methods(http.MethodGet)
+	router.HandleFunc("/iframe/authenticate", api.authenticate).Methods(http.MethodGet)
+	router.HandleFunc("/iframe/notification_preview", api.iframeNotificationPreview).Methods(http.MethodGet)
+	router.HandleFunc("/iframe-manifest", api.appManifest).Methods(http.MethodGet)
 
 	return api
 }

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -34,7 +34,7 @@ func TestIFrame(t *testing.T) {
 
 		// Check for CSP headers
 		assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "style-src 'nonce-")
-		assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "script-src 'self' https://res.cdn.office.net 'nonce-")
+		assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "script-src https://res.cdn.office.net 'nonce-")
 		assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
 		assert.Equal(t, "strict-origin-when-cross-origin", resp.Header.Get("Referrer-Policy"))
 

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -33,7 +33,8 @@ func TestIFrame(t *testing.T) {
 		assert.Equal(t, "text/html", resp.Header.Get("Content-Type"))
 
 		// Check for CSP headers
-		assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "style-src 'unsafe-inline'")
+		assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "style-src 'nonce-")
+		assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "script-src 'self' https://res.cdn.office.net 'nonce-")
 		assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
 		assert.Equal(t, "strict-origin-when-cross-origin", resp.Header.Get("Referrer-Policy"))
 

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -74,10 +74,12 @@ func (a *API) iFrame(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set a minimal CSP for the wrapper page
+	// cspDirectives is a minimal CSP for the wrapper page
+	// style-src: Allow inline styles with nonce
+	// script-src: Allow scripts from Microsoft Teams CDN and inline scripts with nonce
 	cspDirectives := []string{
-		"style-src 'nonce-" + iframeCtx.Nonce + "'",                                     // Allow inline styles with nonce
-		"script-src 'self' https://res.cdn.office.net 'nonce-" + iframeCtx.Nonce + "';", // Allow scripts from Microsoft Teams CDN and inline scripts with nonce
+		"style-src 'nonce-" + iframeCtx.Nonce + "'",
+		"script-src https://res.cdn.office.net 'nonce-" + iframeCtx.Nonce + "';",
 	}
 	w.Header().Set("Content-Security-Policy", strings.Join(cspDirectives, "; "))
 	w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -60,8 +60,8 @@ func (a *API) iFrame(w http.ResponseWriter, r *http.Request) {
 
 	// Generate a random nonce for the script/style tag
 	nonceBytes := make([]byte, 16)
-	if _, err := rand.Read(nonceBytes); err != nil {
-		a.p.API.LogError("Failed to generate nonce", "error", err.Error())
+	if _, nonceErr := rand.Read(nonceBytes); nonceErr != nil {
+		a.p.API.LogError("Failed to generate nonce", "error", nonceErr.Error())
 		http.Error(w, "Failed to generate nonce", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
#### Summary

- Replace hard-coded HTTP verbs with constants
- Run JavaScript in IIFE (immediately invoked function expression) so everything is locally scoped and not polluting the global scope
- Improve CSP to use a nonce for JavaScript/CSS as opposed to `unsafe-inline`

#### Ticket Link

NA

