### PR TITLE
Add robust CSP with CSP reporting

### DIFF
--- a/assets/iframe_notification_preview.html.tmpl
+++ b/assets/iframe_notification_preview.html.tmpl
@@ -8,7 +8,11 @@
         integrity="sha384-brW9AazbKR2dYw2DucGgWCCcmrm2oBFV4HQidyuyZRI/TnAkmOOnTARSTdps3Hwt"
         crossorigin="anonymous"
     ></script>
-    <script src="https://cdn.jsdelivr.net/npm/marked@4.3.0/marked.min.js"></script>
+    <script 
+        src="https://cdn.jsdelivr.net/npm/marked@4.3.0/marked.min.js"
+        integrity="sha384-QsSpx6a0USazT7nK7w8qXDgpSAPhFsb2XtpoLFQ5+X2yFN6hvCKnwEzN8M5FWaJb"
+        crossorigin="anonymous"
+    ></script>
 
     <style nonce="{{.Nonce}}">
         :root {

--- a/assets/iframe_notification_preview.html.tmpl
+++ b/assets/iframe_notification_preview.html.tmpl
@@ -10,7 +10,7 @@
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/marked@4.3.0/marked.min.js"></script>
 
-    <style>
+    <style nonce="{{.Nonce}}">
         :root {
             /* Base colors */
             --color-white: #ffffff;
@@ -194,36 +194,53 @@
     </style>
 </head>
 <body>
-    <script>
+    <script nonce="{{.Nonce}}">
+        // Variables that need to be in global scope
         let context;
         let currentUserId = "{{.UserID}}";
 
-        async function initializeTeams() {
-            try {
-                await microsoftTeams.app.initialize(["{{.SiteURL}}"]);
-                microsoftTeams.app.notifySuccess();
-            } catch (error) {
-                console.error('Failed to initialize Microsoft Teams SDK:', error);
+        // IIFE for initialization and utility functions
+        (function() {
+            // Initialize Teams SDK
+            async function initializeTeams() {
+                try {
+                    await microsoftTeams.app.initialize(["{{.SiteURL}}"]);
+                    microsoftTeams.app.notifySuccess();
+                } catch (error) {
+                    console.error('Failed to initialize Microsoft Teams SDK:', error);
+                }
             }
-        }
 
-        function formatDate(timestamp) {
-            const date = new Date(timestamp);
-            return date.toLocaleString();
-        }
+            // Format date utility function
+            function formatDate(timestamp) {
+                const date = new Date(timestamp);
+                return date.toLocaleString();
+            }
 
-        function goToMattermost() {
-            microsoftTeams.pages.navigateToApp({
-                appId: context.app.appId.appIdAsString,
-                subPageId: 'post_{{.Post.Id}}'
+            // Function to navigate to Mattermost
+            function goToMattermost() {
+                microsoftTeams.pages.navigateToApp({
+                    appId: context.app.appId.appIdAsString,
+                    subPageId: 'post_{{.Post.Id}}'
+                });
+            }
+
+            // Initialize Teams SDK
+            initializeTeams();
+            microsoftTeams.app.getContext().then((c) => {
+                context = c;
             });
-        }
 
-        // Initialize everything
-        initializeTeams();
-        microsoftTeams.app.getContext().then((c) => {
-            context = c;
-        });
+            // Set up window.onload to handle DOM-dependent operations
+            window.onload = function() {
+                // Render the message as markdown
+                const messageContent = `{{.Post.Message}}`;
+                document.getElementById('message-content').innerHTML = marked.parse(messageContent);
+                
+                // Add event listener to the view link
+                document.getElementById('view-in-mattermost').addEventListener('click', goToMattermost);
+            };
+        })();
     </script>
 
     <div class="notification-container">
@@ -247,16 +264,11 @@
             </div>
         </div>
         <div class="message-footer">
-            <a class="view-link" onclick="goToMattermost();">
+            <a class="view-link" id="view-in-mattermost">
                 View in Mattermost
             </a>
             Originally posted in <span>{{.NotificationPreviewContext.ChannelNameDisplay}}</span>
         </div>
     </div>
-    <script>
-        // Render the message as markdown
-        const messageContent = `{{.Post.Message}}`;
-        document.getElementById('message-content').innerHTML = marked.parse(messageContent);
-    </script>
 </body>
 </html>

--- a/server/api.go
+++ b/server/api.go
@@ -29,6 +29,7 @@ func NewAPI(p *Plugin) *API {
 	router.HandleFunc("/iframe/authenticate", api.authenticate).Methods(http.MethodGet)
 	router.HandleFunc("/iframe/notification_preview", api.iframeNotificationPreview).Methods(http.MethodGet)
 	router.HandleFunc("/iframe-manifest", api.appManifest).Methods(http.MethodGet)
+	router.HandleFunc("/csp-report", api.cspReport).Methods(http.MethodPost)
 
 	return api
 }

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -59,15 +59,6 @@ func (a *API) iFrame(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Generate a random nonce for the script/style tag
-	nonceBytes := make([]byte, 16)
-	if _, nonceErr := rand.Read(nonceBytes); nonceErr != nil {
-		a.p.API.LogError("Failed to generate nonce", "error", nonceErr.Error())
-		http.Error(w, "Failed to generate nonce", http.StatusInternalServerError)
-		return
-	}
-	iframeCtx.Nonce = base64.StdEncoding.EncodeToString(nonceBytes)
-
 	html, err := a.formatTemplate(assets.IFrameHTMLTemplate, iframeCtx)
 	if err != nil {
 		a.p.API.LogError("Failed to format iFrame HTML", "error", err.Error())
@@ -147,15 +138,6 @@ func (a *API) iframeNotificationPreview(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Generate a random nonce for the script/style tag
-	nonceBytes := make([]byte, 16)
-	if _, nonceErr := rand.Read(nonceBytes); nonceErr != nil {
-		a.p.API.LogError("Failed to generate nonce", "error", nonceErr.Error())
-		http.Error(w, "Failed to generate nonce", http.StatusInternalServerError)
-		return
-	}
-	iFrameCtx.Nonce = base64.StdEncoding.EncodeToString(nonceBytes)
-
 	html, err := a.formatTemplate(assets.IFrameNotificationPreviewHTMLTemplate, iFrameCtx)
 	if err != nil {
 		a.p.API.LogError("Failed to format iFrame HTML", "error", err.Error())
@@ -209,6 +191,13 @@ func (a *API) createIFrameContext(userID string, post *model.Post) (iFrameContex
 		UserID:   userID,
 		Post:     post,
 	}
+
+	// Generate a random nonce for the script/style tags
+	nonceBytes := make([]byte, 16)
+	if _, nonceErr := rand.Read(nonceBytes); nonceErr != nil {
+		return iFrameContext{}, fmt.Errorf("failed to generate nonce: %w", nonceErr)
+	}
+	iFrameCtx.Nonce = base64.StdEncoding.EncodeToString(nonceBytes)
 
 	// If the post is nil, we don't need to do anything else.
 	if post == nil {

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -75,7 +75,7 @@ func (a *API) iFrame(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// cspDirectives is a minimal CSP for the wrapper page
+	// cspDirectives is a CSP for the wrapper page
 	// default-src: Block all resources by default
 	// style-src: Allow inline styles with nonce
 	// script-src: Allow scripts from Microsoft Teams CDN and inline scripts with nonce


### PR DESCRIPTION
#### Summary

- Make CSP more robust
- Add CSP reporting endpoint for when CSP rejects things
- Refactor JavaScript in `iframe_notification_preview.html.tmpl` so that it can use a nonce
- Refactor JavaScript in `iframe_notification_preview.html.tmpl` so where possible an IIFE can be used to reduce things in the global scope.
- Combine two `script` tags in `iframe_notification_preview.html.tmpl` so the JavaScript is in one place and use `window.onload` where needed

#### Ticket Link

NA
