### PR TITLE
feat: add config for teams app ID instead of retrieving it from context

### DIFF
--- a/assets/iframe.html.tmpl
+++ b/assets/iframe.html.tmpl
@@ -51,8 +51,7 @@
         if (tenantId === expectedTenantId) {
           // Build query params to be sent to the iframe.
           const params = new URLSearchParams()
-          params.set('app_id', context.app.appId.appIdAsString);
-    
+
           // Extract the subPageId (subEntityId coming from the Microsoft Teams SDK User Activity notification)
           // and send it to the iframe to redirect the user to what triggered the notification.
           if (context && context.page && context.page.subPageId) {

--- a/assets/iframe_notification_preview.html.tmpl
+++ b/assets/iframe_notification_preview.html.tmpl
@@ -214,7 +214,7 @@
 
         function goToMattermost() {
             microsoftTeams.pages.navigateToApp({
-                appId: context.app.appId.appIdAsString,
+                appId: '{{.TeamsAppID}}',
                 subPageId: 'post_{{.Post.Id}}'
             });
         }

--- a/plugin.json
+++ b/plugin.json
@@ -35,6 +35,13 @@
                 "default": ""
             },
             {
+                "key": "teamsAppID",
+                "display_name": "Teams App ID",
+                "type": "text",
+                "help_text": "A unique identifier for the Teams application, this can be found in the [teams administration](https://admin.teams.microsoft.com/policies/manage-apps). This is used to identify the Teams application installation in Microsoft 365.",
+                "default": ""
+            },
+            {
                 "key": "tenantID",
                 "display_name": "Tenant ID",
                 "type": "text",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -21,6 +21,7 @@ import (
 type configuration struct {
 	AppVersion                       string `json:"appVersion"`
 	AppID                            string `json:"appID"`
+	TeamsAppID                       string `json:"teamsAppID"`
 	AppClientID                      string `json:"appClientID"`
 	AppClientSecret                  string `json:"appClientSecret"`
 	AppName                          string `json:"appName"`
@@ -33,6 +34,7 @@ func (c *configuration) ProcessConfiguration() {
 	c.TenantID = strings.TrimSpace(c.TenantID)
 	c.AppClientID = strings.TrimSpace(c.AppClientID)
 	c.AppClientSecret = strings.TrimSpace(c.AppClientSecret)
+	c.TeamsAppID = strings.TrimSpace(c.TeamsAppID)
 }
 
 func (p *Plugin) validateConfiguration(configuration *configuration) error {
@@ -43,6 +45,9 @@ func (p *Plugin) validateConfiguration(configuration *configuration) error {
 	}
 	if configuration.AppID == "" {
 		return errors.New("application ID should not be empty")
+	}
+	if configuration.TeamsAppID == "" {
+		return errors.New("teams app ID should not be empty")
 	}
 	if configuration.TenantID == "" {
 		return errors.New("tenant ID should not be empty")
@@ -55,6 +60,9 @@ func (p *Plugin) validateConfiguration(configuration *configuration) error {
 	}
 	if configuration.AppName == "" {
 		return errors.New("app name should not be empty")
+	}
+	if !configuration.DisableUserActivityNotifications && configuration.TeamsAppID == "" {
+		return errors.New("teams app ID should not be empty if user activity notifications are enabled")
 	}
 	return nil
 }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -46,9 +46,7 @@ func (p *Plugin) validateConfiguration(configuration *configuration) error {
 	if configuration.AppID == "" {
 		return errors.New("application ID should not be empty")
 	}
-	if configuration.TeamsAppID == "" {
-		return errors.New("teams app ID should not be empty")
-	}
+// Removed redundant unconditional validation for TeamsAppID.
 	if configuration.TenantID == "" {
 		return errors.New("tenant ID should not be empty")
 	}

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -261,7 +261,7 @@ func (p *NotificationsParser) sendChannelNotification(un *UserNotification, onli
 
 func (p *NotificationsParser) sendUserActivity(userActivity *UserActivity) error {
 	if p.configuration.TeamsAppID == "" {
-		return fmt.Errorf("Can't send user activity if TeamsAppID is not set in the configuration")
+		return fmt.Errorf("can't send user activity if TeamsAppID is not set in the configuration")
 	}
 
 	sender, appErr := p.PAPI.GetUser(userActivity.UserNotification.Post.UserId)

--- a/server/store/pluginstore/store.go
+++ b/server/store/pluginstore/store.go
@@ -27,8 +27,6 @@ func NewUser(mattermostUserID, teamsObjectID, teamsSSOUsername string) *User {
 type Store interface {
 	StoreUser(user *User) error
 	GetUser(mattermostUserID string) (*User, error)
-	StoreAppID(appID string) error
-	GetAppID() (string, error)
 }
 
 type PluginStore struct {
@@ -69,28 +67,6 @@ func (s *PluginStore) GetUser(mattermostUserID string) (*User, error) {
 		return nil, fmt.Errorf("failed to unmarshal user %s: %w", mattermostUserID, err)
 	}
 	return &user, nil
-}
-
-func (s *PluginStore) StoreAppID(appID string) error {
-	appErr := s.API.KVSet(getAppIDKey(), []byte(appID))
-	if appErr != nil {
-		return fmt.Errorf("failed to store app ID: %w", appErr)
-	}
-
-	return nil
-}
-
-func (s *PluginStore) GetAppID() (string, error) {
-	appIDBytes, appErr := s.API.KVGet(getAppIDKey())
-	if appErr != nil {
-		return "", fmt.Errorf("failed to get app ID: %w", appErr)
-	}
-
-	if appIDBytes == nil {
-		return "", fmt.Errorf("app ID not found")
-	}
-
-	return string(appIDBytes), nil
 }
 
 func getUserKey(mattermostUserID string) string {

--- a/server/store/pluginstore/store.go
+++ b/server/store/pluginstore/store.go
@@ -72,7 +72,3 @@ func (s *PluginStore) GetUser(mattermostUserID string) (*User, error) {
 func getUserKey(mattermostUserID string) string {
 	return fmt.Sprintf("user:%s", mattermostUserID)
 }
-
-func getAppIDKey() string {
-	return "appID"
-}


### PR DESCRIPTION
#### Why
Loading the Mattermost tab application in mobile teams give us a different context that **does not contain** the appID for the application installation in teams. We need that ID to send user activity notifications and point the notification to the application tab

#### Summary
- Adds a new configuration for the Teams App ID
- Removes logic to store/retrieve the appID from the KVStore.

#### Caveats

Requires updating the documentation, since we now have a "chicken and egg" problem, since user activities are enabled by default but we need the Teams App ID for them to work, **but** we need to fill in the configuration from the Azure admin, download the manifest and install the app in teams to get that missing ID.

The configuration now looks like:
- Follow README until `#8`
9. Download the manifest and install the app
10. Retrieve the teams app ID from the teams admin
11. Set up the teams app ID in the plugin configuration and enable user activities

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63824
