### PR TITLE
feat: retrieve appID from server using api call

### DIFF
--- a/assets/iframe.html.tmpl
+++ b/assets/iframe.html.tmpl
@@ -72,10 +72,8 @@
 
         // If the expected tenant matches the actual tenant then try to get auth token
         if (tenantId === expectedTenantId) {
+          var params = new URLSearchParams();
           // Build query params to be sent to the iframe.
-          const params = new URLSearchParams()
-          params.set('app_id', context.app.appId.appIdAsString);
-
           // Extract the subPageId (subEntityId coming from the Microsoft Teams SDK User Activity notification)
           // and send it to the iframe to redirect the user to what triggered the notification.
           if (context && context.page && context.page.subPageId) {

--- a/docs/admin_setup.md
+++ b/docs/admin_setup.md
@@ -25,6 +25,7 @@
 6. Go to **API Permissions**
     - Ensure `User.Read` **delegated** permission is added ([Microsoft documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/authentication/tab-sso-register-aad#enable-sso-in-microsoft-entra-id))
     - Add `TeamsActivity.Send` **application** permission (optional, for notifications) ([Microsoft documentation](https://learn.microsoft.com/en-us/graph/teams-send-activityfeednotifications?tabs=desktop%2Chttp))
+    - Add `AppCatalog.Read.All` **application** permission. (optional, for notifications) ([Microsoft documentation](https://learn.microsoft.com/en-us/graph/api/appcatalogs-list-teamsapps?view=graph-rest-1.0&tabs=http))
     - Grant admin consent for the default directory to prevent users from seeing the consent prompt.
 
 7. Go to **Expose an API**

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -372,18 +372,6 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	appID := r.URL.Query().Get("app_id")
-	if appID == "" {
-		logger.Error("App ID was not sent with the authentication request")
-	}
-
-	err = a.p.pluginStore.StoreAppID(appID)
-	if err != nil {
-		logger.WithError(err).Error("Failed to store app ID")
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-
 	// This is effectively copied from https://github.com/mattermost/mattermost/blob/a184e5677d28433495b0cde764bfd99700838740/server/channels/app/login.go#L287
 	secure := true
 	maxAgeSeconds := *config.ServiceSettings.SessionLengthWebInHours * 60 * 60

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -453,7 +453,7 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 		return
 	}
 
-	if err := parser.SendNotifications(); err != nil {
+	if err := parser.SendNotifications(p.configuration.TenantID); err != nil {
 		p.API.LogError("Failed to send notifications", "error", err.Error())
 	}
 }

--- a/server/msteams/interface.go
+++ b/server/msteams/interface.go
@@ -61,5 +61,6 @@ type Client interface {
 	ListChatMessages(chatID string, since time.Time) ([]*clientmodels.Message, error)
 	GetApp(applicationID string) (*clientmodels.App, error)
 	GetPresencesForUsers(userIDs []string) (map[string]clientmodels.Presence, error)
+	GetTeamsAppIDByExternalID(externalID string) (string, error)
 	SendUserActivity(userIDs []string, activityType, message string, webURL url.URL, params map[string]string) error
 }

--- a/server/msteams/mocks/Client.go
+++ b/server/msteams/mocks/Client.go
@@ -521,6 +521,34 @@ func (_m *Client) GetPresencesForUsers(userIDs []string) (map[string]clientmodel
 	return r0, r1
 }
 
+// GetTeamsAppIDByExternalID provides a mock function with given fields: externalID
+func (_m *Client) GetTeamsAppIDByExternalID(externalID string) (string, error) {
+	ret := _m.Called(externalID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTeamsAppIDByExternalID")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return rf(externalID)
+	}
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(externalID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(externalID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetReply provides a mock function with given fields: teamID, channelID, messageID, replyID
 func (_m *Client) GetReply(teamID string, channelID string, messageID string, replyID string) (*clientmodels.Message, error) {
 	ret := _m.Called(teamID, channelID, messageID, replyID)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -278,6 +278,21 @@ func (p *Plugin) connectTeamsAppClient() error {
 		return err
 	}
 
+	// Retrieve the Teams application ID by external ID (using AppClientID)
+	if p.getConfiguration().AppClientID != "" {
+		appID, err := p.msteamsAppClient.GetTeamsAppIDByExternalID(p.getConfiguration().AppID)
+		if err != nil {
+			p.API.LogError("Unable to retrieve Teams application ID", "error", err)
+			// Continue even if we couldn't retrieve the app ID, it's not essential for all operations
+		} else {
+			if err := p.pluginStore.StoreAppID(appID); err != nil {
+				p.API.LogError("Unable to store Teams application ID", "error", err)
+			} else {
+				p.API.LogDebug("Retrieved Teams application ID", "appID", appID)
+			}
+		}
+	}
+
 	// Get a local copy of the context to use in the goroutine
 	p.clientReconnectLock.Lock()
 	ctx := p.clientReconnectCtx

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -285,7 +285,7 @@ func (p *Plugin) connectTeamsAppClient() error {
 			p.API.LogError("Unable to retrieve Teams application ID", "error", err)
 			// Continue even if we couldn't retrieve the app ID, it's not essential for all operations
 		} else {
-			if err := p.pluginStore.StoreAppID(appID); err != nil {
+			if err := p.pluginStore.StoreAppID(p.configuration.TenantID, appID); err != nil {
 				p.API.LogError("Unable to store Teams application ID", "error", err)
 			} else {
 				p.API.LogDebug("Retrieved Teams application ID", "appID", appID)

--- a/server/store/pluginstore/store.go
+++ b/server/store/pluginstore/store.go
@@ -71,8 +71,8 @@ func (s *PluginStore) GetUser(mattermostUserID string) (*User, error) {
 	return &user, nil
 }
 
-func (s *PluginStore) StoreAppID(appID string) error {
-	appErr := s.API.KVSet(getAppIDKey(), []byte(appID))
+func (s *PluginStore) StoreAppID(tenantID, appID string) error {
+	appErr := s.API.KVSet(getAppIDKey(tenantID), []byte(appID))
 	if appErr != nil {
 		return fmt.Errorf("failed to store app ID: %w", appErr)
 	}
@@ -80,8 +80,8 @@ func (s *PluginStore) StoreAppID(appID string) error {
 	return nil
 }
 
-func (s *PluginStore) GetAppID() (string, error) {
-	appIDBytes, appErr := s.API.KVGet(getAppIDKey())
+func (s *PluginStore) GetAppID(tenantID string) (string, error) {
+	appIDBytes, appErr := s.API.KVGet(getAppIDKey(tenantID))
 	if appErr != nil {
 		return "", fmt.Errorf("failed to get app ID: %w", appErr)
 	}
@@ -97,6 +97,6 @@ func getUserKey(mattermostUserID string) string {
 	return fmt.Sprintf("user:%s", mattermostUserID)
 }
 
-func getAppIDKey() string {
-	return "appID"
+func getAppIDKey(tenantID string) string {
+	return "appid_" + tenantID
 }


### PR DESCRIPTION
#### Summary
- Removed the `app_id` retrieval on the authentication flow
- Application ID is now retrieved directly from the backend using the Teams API, a new permission in the application is required. 
- Docs updated.
- Store the appID using the tenant ID as key prefix to have a link between the two for future optimizations (multi tenant setup)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63824?linkSource=email
