### PR TITLE
Bump minimum server version

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-msteams-devsecops",
     "support_url": "https://github.com/mattermost/mattermost-plugin-msteams-devsecops/issues",
     "icon_path": "assets/devsecops.svg",
-    "min_server_version": "6.2.1",
+    "min_server_version": "10.7.1",
     "server": {
         "executables": {
             "darwin-arm64": "server/dist/plugin-darwin-arm64",


### PR DESCRIPTION
#### Summary
This plugin requires support added in MM server version 10.7, with important fixes in 10.7.1

#### Ticket Link
NONE