### PR TITLE
Remove `noroute` query param

### DIFF
--- a/assets/appmanifest.json.tmpl
+++ b/assets/appmanifest.json.tmpl
@@ -27,13 +27,13 @@
         {
             "entityId": "Mattermost",
             "name": "Mattermost",
-            "contentUrl": "https://{{.SiteDomainPath}}/plugins/{{.PluginID}}/iframe/mattermostTab?noroute",
+            "contentUrl": "https://{{.SiteDomainPath}}/plugins/{{.PluginID}}/iframe/mattermostTab",
             "scopes": ["personal"]
         },
         {
             "entityId": "notification_preview",
             "name": "Notification Preview",
-            "contentUrl": "https://{{.SiteDomainPath}}/plugins/{{.PluginID}}/iframe/mattermostTab?action=notification_preview&noroute",
+            "contentUrl": "https://{{.SiteDomainPath}}/plugins/{{.PluginID}}/iframe/mattermostTab?action=notification_preview",
             "scopes": ["personal"]
         },
         {

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -286,10 +286,6 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// check if the `noroute` query param is set, which will skip the routing.
-	noroute := false
-	_, noroute = r.URL.Query()["noroute"]
-
 	config := a.p.client.Configuration.GetConfig()
 
 	enableDeveloper := config.ServiceSettings.EnableDeveloper
@@ -307,7 +303,6 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 		enableDeveloper:   enableDeveloper != nil && *enableDeveloper,
 		siteURL:           *config.ServiceSettings.SiteURL,
 		clientID:          a.p.configuration.AppClientID,
-		disableRouting:    noroute,
 	}
 
 	claims, validationErr := validateToken(params)

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -40,7 +40,6 @@ type validateTokenParams struct {
 	enableDeveloper   bool
 	siteURL           string
 	clientID          string
-	disableRouting    bool
 }
 
 func setupJWKSet() (keyfunc.Keyfunc, context.CancelFunc) {
@@ -105,15 +104,11 @@ func validateToken(params *validateTokenParams) (jwt.MapClaims, *validationError
 	}
 
 	// Verify that this token was signed for the expected app, unless developer mode is enabled.
-	// If routing is disabled, then use this server's domain and client to verify the audience,
-	// otherwise use Community's domain and client, as it will route to the correct server.
 	switch {
 	case params.enableDeveloper:
 		logrus.Warn("Skipping aud claim check for token since developer mode enabled")
-	case params.disableRouting:
-		options = append(options, jwt.WithAudience(fmt.Sprintf(ExpectedAudienceFmt, mmServerURL.Host, params.clientID)))
 	default:
-		options = append(options, jwt.WithAudience(ExpectedAudience))
+		options = append(options, jwt.WithAudience(fmt.Sprintf(ExpectedAudienceFmt, mmServerURL.Host, params.clientID)))
 	}
 
 	parsed, err := jwt.Parse(

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -19,7 +19,6 @@ import (
 
 const (
 	MicrosoftOnlineJWKSURL = "https://login.microsoftonline.com/common/discovery/v2.0/keys"
-	ExpectedAudience       = "api://community.mattermost.com/4ef56ea2-4a2f-4817-a6e0-a7cd760e2034"
 	ExpectedAudienceFmt    = "api://%s/%s"
 )
 

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -443,12 +444,16 @@ func TestValidateToken(t *testing.T) {
 		t.Run("signed token, matching single configured tenant", func(t *testing.T) {
 			tid := uuid.NewString()
 
+			// Parse the TestSiteURL to get just the host for the audience
+			siteURL, err := url.Parse(TestSiteURL)
+			require.NoError(t, err)
+
 			_, priv, jwtKeyFunc := makeKeySet(t)
 			token := newToken(t, priv, jwt.MapClaims{
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": fmt.Sprintf(ExpectedAudienceFmt, TestSiteURL, TestClientID),
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, siteURL.Host, TestClientID),
 				"tid": tid,
 			})
 

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -448,33 +448,17 @@ func TestValidateToken(t *testing.T) {
 				"iat": past(),
 				"exp": future(),
 				"nbf": past(),
-				"aud": ExpectedAudience,
+				"aud": fmt.Sprintf(ExpectedAudienceFmt, TestSiteURL, TestClientID),
 				"tid": tid,
 			})
 
 			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
 
 			_, validationErr := validateToken(params)
-			assert.Nil(t, validationErr)
-		})
-
-		t.Run("signed token, matching one of multiple configured tenants", func(t *testing.T) {
-			expectedTid1 := uuid.NewString()
-			expectedTid2 := uuid.NewString()
-
-			_, priv, jwtKeyFunc := makeKeySet(t)
-			token := newToken(t, priv, jwt.MapClaims{
-				"iat": past(),
-				"exp": future(),
-				"nbf": past(),
-				"aud": ExpectedAudience,
-				"tid": expectedTid1,
-			})
-
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{expectedTid1, expectedTid2}, enableDeveloper)
-
-			_, validationErr := validateToken(params)
-			assert.Nil(t, validationErr)
+			if validationErr != nil {
+				assert.NoError(t, validationErr.Err)
+				t.Fail()
+			}
 		})
 
 		t.Run("signed token, wildcard tenant", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
This PR removes the `noroute` query parameter as we no longer need any routing to alternate MM instances. 

#### Ticket Link
NONE