### PR TITLE
No longer skip token validation in developer mode

### DIFF
--- a/server/api_test.go
+++ b/server/api_test.go
@@ -106,7 +106,7 @@ func TestAuthenticate(t *testing.T) {
 
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		assert.Contains(t, string(body), "Invalid token")
+		assert.Contains(t, string(body), "Missing token")
 	})
 }
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"reflect"
 	"strings"
 
@@ -137,4 +138,16 @@ func (p *Plugin) OnConfigurationChange() error {
 	}
 
 	return nil
+}
+
+// shouldSkipTokenValidation returns true if the token validation should be skipped based on
+// the MM_DEVSECOPS_SKIP_TOKEN_VALIDATION environment var is set to true.
+func shouldSkipTokenValidation() bool {
+	if skipTokenValidation, ok := os.LookupEnv("MM_DEVSECOPS_SKIP_TOKEN_VALIDATION"); ok {
+		switch strings.ToLower(skipTokenValidation) {
+		case "1", "true", "yes":
+			return true
+		}
+	}
+	return false
 }

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -288,8 +288,6 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 
 	config := a.p.client.Configuration.GetConfig()
 
-	enableDeveloper := config.ServiceSettings.EnableDeveloper
-
 	// Ideally we'd accept the token via an Authorization header, but for now get it from the query string.
 	// token := r.Header.Get("Authorization")
 	token := r.URL.Query().Get("token")
@@ -297,12 +295,12 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 	// Validate the token in the request, handling all errors if invalid.
 	expectedTenantIDs := []string{a.p.getConfiguration().TenantID}
 	params := &validateTokenParams{
-		jwtKeyFunc:        a.p.tabAppJWTKeyFunc,
-		token:             token,
-		expectedTenantIDs: expectedTenantIDs,
-		enableDeveloper:   enableDeveloper != nil && *enableDeveloper,
-		siteURL:           *config.ServiceSettings.SiteURL,
-		clientID:          a.p.configuration.AppClientID,
+		jwtKeyFunc:          a.p.tabAppJWTKeyFunc,
+		token:               token,
+		expectedTenantIDs:   expectedTenantIDs,
+		skipTokenValidation: shouldSkipTokenValidation(),
+		siteURL:             *config.ServiceSettings.SiteURL,
+		clientID:            a.p.configuration.AppClientID,
 	}
 
 	claims, validationErr := validateToken(params)

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -59,11 +59,10 @@ func validateToken(params *validateTokenParams) (jwt.MapClaims, *validationError
 		if params.skipTokenValidation {
 			logrus.Warn("Skipping token validation check for empty token since skip token validation mode enabled")
 			return nil, nil
-		} else {
-			return nil, &validationError{
-				StatusCode: http.StatusUnauthorized,
-				Message:    "Missing token",
-			}
+		}
+		return nil, &validationError{
+			StatusCode: http.StatusUnauthorized,
+			Message:    "Missing token",
 		}
 	}
 

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -58,6 +58,7 @@ func validateToken(params *validateTokenParams) (jwt.MapClaims, *validationError
 	if params.token == "" {
 		if params.skipTokenValidation {
 			logrus.Warn("Skipping token validation check for empty token since skip token validation mode enabled")
+			return nil, nil
 		} else {
 			return nil, &validationError{
 				StatusCode: http.StatusUnauthorized,

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -112,29 +112,29 @@ func TestValidateToken(t *testing.T) {
 		TestClientID = "app-id"
 	)
 
-	makeValidateTokenParams := func(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs []string, enableDeveloper bool) *validateTokenParams {
+	makeValidateTokenParams := func(jwtKeyFunc keyfunc.Keyfunc, token string, expectedTenantIDs []string, skipTokenValidation bool) *validateTokenParams {
 		return &validateTokenParams{
-			jwtKeyFunc:        jwtKeyFunc,
-			token:             token,
-			expectedTenantIDs: expectedTenantIDs,
-			enableDeveloper:   enableDeveloper,
-			siteURL:           TestSiteURL,
-			clientID:          TestClientID,
+			jwtKeyFunc:          jwtKeyFunc,
+			token:               token,
+			expectedTenantIDs:   expectedTenantIDs,
+			skipTokenValidation: skipTokenValidation,
+			siteURL:             TestSiteURL,
+			clientID:            TestClientID,
 		}
 	}
 
 	type permutations struct {
-		EnableDeveloper bool
+		SkipTokenValidation bool
 	}
 
 	runPermutations(t, permutations{}, func(t *testing.T, permutation permutations) {
-		enableDeveloper := permutation.EnableDeveloper
+		skipTokenValidation := permutation.SkipTokenValidation
 		t.Run("empty authorization header", func(t *testing.T) {
 			_, _, jwtKeyFunc := makeKeySet(t)
-			params := makeValidateTokenParams(jwtKeyFunc, "", []string{}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, "", []string{}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
-			if enableDeveloper {
+			if skipTokenValidation {
 				assert.Nil(t, validationErr)
 			} else {
 				require.NotNil(t, validationErr)
@@ -143,7 +143,7 @@ func TestValidateToken(t *testing.T) {
 		})
 
 		t.Run("nil keyfunc", func(t *testing.T) {
-			params := makeValidateTokenParams(nil, "invalid", []string{}, enableDeveloper)
+			params := makeValidateTokenParams(nil, "invalid", []string{}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -152,7 +152,7 @@ func TestValidateToken(t *testing.T) {
 
 		t.Run("failed to parse authorization header", func(t *testing.T) {
 			_, _, jwtKeyFunc := makeKeySet(t)
-			params := makeValidateTokenParams(jwtKeyFunc, "invalid", []string{}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, "invalid", []string{}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -161,7 +161,7 @@ func TestValidateToken(t *testing.T) {
 
 		t.Run("signed token, missing claims", func(t *testing.T) {
 			_, priv, jwtKeyFunc := makeKeySet(t)
-			params := makeValidateTokenParams(jwtKeyFunc, newToken(t, priv, nil), []string{}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, newToken(t, priv, nil), []string{}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -183,7 +183,7 @@ func TestValidateToken(t *testing.T) {
 			token, err := jwtToken.SignedString([]byte(pub))
 			require.NoError(t, err)
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -201,7 +201,7 @@ func TestValidateToken(t *testing.T) {
 				"tid": tid,
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -220,7 +220,7 @@ func TestValidateToken(t *testing.T) {
 				"tid": tid,
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -239,7 +239,7 @@ func TestValidateToken(t *testing.T) {
 				"tid": tid,
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -257,7 +257,7 @@ func TestValidateToken(t *testing.T) {
 				"aud": fmt.Sprintf(ExpectedAudienceFmt, TestSiteURL, TestClientID),
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -276,7 +276,7 @@ func TestValidateToken(t *testing.T) {
 				"aud": fmt.Sprintf(ExpectedAudienceFmt, TestSiteURL, TestClientID),
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -295,7 +295,7 @@ func TestValidateToken(t *testing.T) {
 				"aud": fmt.Sprintf(ExpectedAudienceFmt, TestSiteURL, TestClientID),
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -313,7 +313,7 @@ func TestValidateToken(t *testing.T) {
 				"aud": fmt.Sprintf(ExpectedAudienceFmt, TestSiteURL, TestClientID),
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -332,7 +332,7 @@ func TestValidateToken(t *testing.T) {
 				"aud": fmt.Sprintf(ExpectedAudienceFmt, TestSiteURL, TestClientID),
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -351,7 +351,7 @@ func TestValidateToken(t *testing.T) {
 				"aud": fmt.Sprintf(ExpectedAudienceFmt, TestSiteURL, TestClientID),
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -370,10 +370,10 @@ func TestValidateToken(t *testing.T) {
 				"aud": "unexpected-app",
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
-			if enableDeveloper {
+			if skipTokenValidation {
 				assert.Nil(t, validationErr)
 			} else {
 				require.NotNil(t, validationErr)
@@ -393,7 +393,7 @@ func TestValidateToken(t *testing.T) {
 				"tid": wrongTid,
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -413,7 +413,7 @@ func TestValidateToken(t *testing.T) {
 				"tid": wrongTid,
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{expectedTid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{expectedTid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -434,7 +434,7 @@ func TestValidateToken(t *testing.T) {
 				"tid": wrongTid,
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{expectedTid1, expectedTid2}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{expectedTid1, expectedTid2}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			require.NotNil(t, validationErr)
@@ -457,7 +457,7 @@ func TestValidateToken(t *testing.T) {
 				"tid": tid,
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{tid}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
 			if validationErr != nil {
@@ -478,10 +478,10 @@ func TestValidateToken(t *testing.T) {
 				"tid": developerTid,
 			})
 
-			params := makeValidateTokenParams(jwtKeyFunc, token, []string{"*"}, enableDeveloper)
+			params := makeValidateTokenParams(jwtKeyFunc, token, []string{"*"}, skipTokenValidation)
 
 			_, validationErr := validateToken(params)
-			if enableDeveloper {
+			if skipTokenValidation {
 				assert.Nil(t, validationErr)
 			} else {
 				require.NotNil(t, validationErr)


### PR DESCRIPTION
#### Summary
Builds on PR https://github.com/mattermost/mattermost-plugin-msteams-devsecops/pull/41

With this PR, developer mode no longer skips token validation. A new environment var `MM_DEVSECOPS_SKIP_TOKEN_VALIDATION` is added to replace this capability.

As much as possible, developers should test their code with token validation enabled.

#### Ticket Link
NONE