### PR TITLE
MM-63941 - Fix bug where Mattermost sessions were only lasting an hour

### DIFF
--- a/server/iframe.go
+++ b/server/iframe.go
@@ -389,7 +389,7 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 
 	// check if the expiration time is in the past
 	if jwtExpiresAt.Time.Before(time.Now()) {
-		logger.Error("Expiration time claim is in the past")
+		logger.Error("Token is already expired")
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -385,7 +385,7 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 	// check if the expiration time is in the past
 	if jwtExpiresAt.Time.Before(time.Now()) {
 		logger.Error("Token is already expired")
-		http.Error(w, "Bad Request", http.StatusBadRequest)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 


### PR DESCRIPTION
#### Summary
Fixes a bug where Mattermost sessions were being expired after an hour, and kicking users back to the login screen while embedded in MS Teams.  Root cause was the session expiry was being set based on the token expiry instead of the configured web session length.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63941