### PR TITLE
fix: add user roles to the session

### DIFF
--- a/server/iframe.go
+++ b/server/iframe.go
@@ -392,6 +392,7 @@ func (a *API) authenticate(w http.ResponseWriter, r *http.Request) {
 	session, err := a.p.client.Session.Create(&model.Session{
 		UserId:    mmUser.Id,
 		ExpiresAt: model.GetMillisForTime(expiresAt),
+		Roles:     mmUser.GetRawRoles(),
 	})
 	if err != nil {
 		logger.WithError(err).Error("Failed to create session for Mattermost user")


### PR DESCRIPTION
#### Summary
Create the session with the user roles to avoid permission errors when running actions after logging in using the plugin and the embedded experience.

Ref: https://github.com/mattermost/mattermost/blob/master/server/channels/app/login.go#L171

#### Ticket Link
