### PR TITLE
Reduce error logging

### DIFF
--- a/server/store/pluginstore/errors.go
+++ b/server/store/pluginstore/errors.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package pluginstore
+
+import "errors"
+
+type ErrNotFound struct {
+	Message string
+}
+
+func (e *ErrNotFound) Error() string {
+	return e.Message
+}
+
+// NewErrNotFound creates a new ErrNotFound with the given message.
+func NewErrNotFound(msg string) *ErrNotFound {
+	return &ErrNotFound{Message: msg}
+}
+
+// IsErrNotFound returns true if the error is of type ErrNotFound, even if wrapped.
+func IsErrNotFound(err error) bool {
+	var notFoundErr *ErrNotFound
+	return errors.As(err, &notFoundErr)
+}

--- a/server/store/pluginstore/store.go
+++ b/server/store/pluginstore/store.go
@@ -60,7 +60,7 @@ func (s *PluginStore) GetUser(mattermostUserID string) (*User, error) {
 	}
 
 	if len(userBytes) == 0 {
-		return nil, fmt.Errorf("user %s not found", mattermostUserID)
+		return nil, NewErrNotFound(fmt.Sprintf("user %s not found", mattermostUserID))
 	}
 
 	var user User
@@ -87,7 +87,7 @@ func (s *PluginStore) GetAppID(tenantID string) (string, error) {
 	}
 
 	if appIDBytes == nil {
-		return "", fmt.Errorf("app ID not found")
+		return "", NewErrNotFound("app ID not found")
 	}
 
 	return string(appIDBytes), nil


### PR DESCRIPTION
#### Summary
When users are mentioned or DM'd who have not used the embedded client, several errors are logged.  This is an expected case and this PR reduces the log level and avoid logging.

#### Ticket Link
NONE