### PR TITLE
fix: corpus app urls and bump to 1.0.6

### DIFF
--- a/appstore/Corpus/manifest.json
+++ b/appstore/Corpus/manifest.json
@@ -1,6 +1,6 @@
 {
     "$schema":"https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "version":"1.0.5",
+    "version":"1.0.6",
     "manifestVersion":"1.19",
     "id":"657fb1fd-da3c-48a7-aa80-5e7d3924931d",
     "name":{


### PR DESCRIPTION
#### Summary

This pull request updates the `manifest.json` file for the `Corpus` app in the App Store. The changes include a version bump and updates to the `contentUrl` values for specific entities.