### PR TITLE
Properly clean up Teams app client on plugin disable to allow re-initialization

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -247,6 +247,11 @@ func (p *Plugin) stop(isRestart bool) {
 			p.cancelKeyFunc = nil
 		}
 		p.cancelKeyFuncLock.Unlock()
+
+		// Clean up the Teams app client so it gets recreated on restart
+		p.msteamsAppClientMutex.Lock()
+		p.msteamsAppClient = nil
+		p.msteamsAppClientMutex.Unlock()
 	}
 }
 


### PR DESCRIPTION
#### Summary
Fixes an issue where disabling and re-enabling the plugin prevents the Teams app ID from being retrieved and stored, causing activity feed notifications to fail with "app ID not found" errors.

##### Problem

When the plugin is disabled and then re-enabled (without a full server restart), the Teams application ID is not retrieved from the Microsoft Teams app catalog. This causes activity feed notifications to fail with the error:
`Failed to send notification: failed to get app ID: app ID not found`

##### Root Cause:
The stop() function does not clean up the msteamsAppClient field when the plugin is deactivated. On re-enable:
  1. OnActivate() calls start() which calls connectTeamsAppClient()
  2. connectTeamsAppClient() checks if p.msteamsAppClient != nil and returns early (line 269)
  3. The code that retrieves and stores the Teams app ID (lines 287-299) never executes
  4. Notifications fail because the app ID is not in the KV store

##### Solution

Added cleanup of msteamsAppClient in the stop() function when isRestart is false, ensuring the client is recreated and the Teams app ID is properly retrieved when the plugin is re-enabled.

#### Ticket Link
https://hub.mattermost.com/private-core/pl/iq8g8zi7ajnwicgupu8bpohcqy
