### PR TITLE
Fix config data race on startup

### DIFF
--- a/server/iframe.go
+++ b/server/iframe.go
@@ -153,9 +153,13 @@ func (a *API) createIFrameContext(userID string, post *model.Post) (iFrameContex
 
 	var appID string
 	var err error
-	appID, err = a.p.pluginStore.GetAppID(a.p.getConfiguration().M365TenantID)
-	if err != nil {
-		a.p.API.LogWarn("Failed to get app ID, button in notification preview won't work", "tenantID", a.p.getConfiguration().M365TenantID, "error", err.Error())
+	// Get the app ID using the client's tenant ID to ensure consistency with storage
+	client := a.p.GetClientForApp()
+	if client != nil {
+		appID, err = a.p.pluginStore.GetAppID(client.GetTenantID())
+		if err != nil {
+			a.p.API.LogWarn("Failed to get app ID, button in notification preview won't work", "tenantID", client.GetTenantID(), "error", err.Error())
+		}
 	}
 
 	iFrameCtx := iFrameContext{

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -47,7 +47,8 @@ func setupJWKSet() (keyfunc.Keyfunc, context.CancelFunc) {
 
 	k, err := keyfunc.NewDefaultCtx(ctx, []string{MicrosoftOnlineJWKSURL})
 	if err != nil {
-		logrus.WithError(err).WithField("jwks_url", MicrosoftOnlineJWKSURL).Error("Failed to create a keyfunc.Keyfunc")
+		logrus.WithError(err).WithField("jwks_url", MicrosoftOnlineJWKSURL).Error("Failed to create a keyfunc.Keyfunc - JWT authentication will not work")
+		return nil, cancelCtx
 	}
 	logrus.Info("Started JWKS monitor")
 


### PR DESCRIPTION
#### Summary
Fixes critical data race condition causing "app ID not found" errors in production after plugin restart or configuration changes. Also adds logging for silent startup failures.

**Primary Issue: App ID Storage Race Condition**
When the plugin was disabled and re-enabled (or configuration was changed), activity feed notifications failed with:
`Failed to send notification: failed to get app ID: app ID not found`

**Root cause:** Data race in `connectTeamsAppClient()` at line 293:
- Storage used `p.configuration.M365TenantID` (unlocked access during config change)
- Retrieval used `p.msteamsAppClient.GetTenantID()` (stable value)
- During configuration changes, storage used the NEW tenant ID while the client still had the OLD tenant ID
- This caused a key mismatch: stored under new tenant ID, retrieved using old tenant ID
-  Result: app ID lookup failed, breaking activity feed notifications

**Secondary Issue: Client Not Recreated on Config Changes**
The MS Teams app client cleanup code was inside the `if !isRestart` block (lines 251-254), meaning:
  - Configuration changes triggered restart with `isRestart=true`
  - Client cleanup was skipped
  - Early return guard in `connectTeamsAppClient()` prevented client recreation
  - Old credentials persisted even after config updates

**Silent Failure Issue**
-  Plugin startup failures were not logged, making it appear the plugin was working when it had actually failed to initialize.

#### Ticket Link
NONE