### PR TITLE
CSP report logging improvements

### DIFF
--- a/server/api_csp.go
+++ b/server/api_csp.go
@@ -5,12 +5,39 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"unicode"
 )
 
 const (
 	DefaultCSPConnectSrc = "https://*.microsoft.com https://*.teams.microsoft.com https://*.cdn.office.net"
 	DefaultCSPScriptSrc  = "https://res.cdn.office.net https://cdn.jsdelivr.net"
+
+	// maxCSPReportFieldLen limits logged CSP report string fields to prevent log injection and size abuse.
+	maxCSPReportFieldLen = 500
 )
+
+// sanitizeForLog replaces newlines and tabs with spaces and truncates to maxCSPReportFieldLen
+// to prevent log injection from attacker-controlled CSP report body fields.
+func sanitizeForLog(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			b.WriteRune(' ')
+		case unicode.IsPrint(r) || r == ' ':
+			b.WriteRune(r)
+		default:
+			b.WriteRune(' ')
+		}
+	}
+	out := b.String()
+	runes := []rune(out)
+	if len(runes) <= maxCSPReportFieldLen {
+		return out
+	}
+	return string(runes[:maxCSPReportFieldLen]) + "..."
+}
 
 // return returnCSPHeaderssets and returns the Content Security Policy headers for the iframe context.
 func (a *API) returnCSPHeaders(w http.ResponseWriter, iFrameCtx iFrameContext) {
@@ -83,7 +110,7 @@ func (a *API) cspReport(w http.ResponseWriter, r *http.Request) {
 
 	// Parse the report
 	if err := json.Unmarshal(body, &reportArray); err != nil {
-		a.p.API.LogError("Failed to parse CSP report", "error", err.Error(), "body", string(body))
+		a.p.API.LogError("Failed to parse CSP report", "error", err.Error(), "body", sanitizeForLog(string(body)))
 		http.Error(w, "Failed to parse report", http.StatusBadRequest)
 		return
 	}
@@ -96,39 +123,39 @@ func (a *API) cspReport(w http.ResponseWriter, r *http.Request) {
 			"age":   report.Age,
 		}
 
-		// Add non-null fields to the map
+		// Add non-null fields to the map; sanitize strings to prevent log injection.
 		if report.Body.BlockedURL != nil {
-			fields["blocked-url"] = *report.Body.BlockedURL
+			fields["blocked-url"] = sanitizeForLog(*report.Body.BlockedURL)
 		}
 		if report.Body.ColumnNumber != nil {
 			fields["column-number"] = *report.Body.ColumnNumber
 		}
 		if report.Body.Disposition != nil {
-			fields["disposition"] = *report.Body.Disposition
+			fields["disposition"] = sanitizeForLog(*report.Body.Disposition)
 		}
 		if report.Body.DocumentURL != nil {
-			fields["document-url"] = *report.Body.DocumentURL
+			fields["document-url"] = sanitizeForLog(*report.Body.DocumentURL)
 		}
 		if report.Body.EffectiveDirective != nil {
-			fields["effective-directive"] = *report.Body.EffectiveDirective
+			fields["effective-directive"] = sanitizeForLog(*report.Body.EffectiveDirective)
 		}
 		if report.Body.LineNumber != nil {
 			fields["line-number"] = *report.Body.LineNumber
 		}
 		if report.Body.OriginalPolicy != nil {
-			fields["original-policy"] = *report.Body.OriginalPolicy
+			fields["original-policy"] = sanitizeForLog(*report.Body.OriginalPolicy)
 		}
 		if report.Body.Referrer != nil {
-			fields["referrer"] = *report.Body.Referrer
+			fields["referrer"] = sanitizeForLog(*report.Body.Referrer)
 		}
 		if report.Body.ScriptSample != nil {
-			fields["script-sample"] = *report.Body.ScriptSample
+			fields["script-sample"] = sanitizeForLog(*report.Body.ScriptSample)
 		}
 		if report.Body.SourceFile != nil {
-			fields["source-file"] = *report.Body.SourceFile
+			fields["source-file"] = sanitizeForLog(*report.Body.SourceFile)
 		}
 		if report.Body.ViolatedDirective != nil {
-			fields["violated-directive"] = *report.Body.ViolatedDirective
+			fields["violated-directive"] = sanitizeForLog(*report.Body.ViolatedDirective)
 		}
 
 		// Log the CSP violation with only the non-null fields

--- a/server/api_csp_test.go
+++ b/server/api_csp_test.go
@@ -17,7 +17,7 @@ func TestSanitizeForLog(t *testing.T) {
 		assert.NotContains(t, out, "\n")
 		assert.NotContains(t, out, "\r")
 		assert.NotContains(t, out, "\t")
-		assert.Equal(t, "line1 line2 line3   tab", out)
+		assert.Equal(t, "line1 line2 line3  tab", out)
 	})
 
 	t.Run("truncates at maxCSPReportFieldLen runes and appends ellipsis", func(t *testing.T) {

--- a/server/api_csp_test.go
+++ b/server/api_csp_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2025-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeForLog(t *testing.T) {
+	t.Run("replaces newlines and tabs with space", func(t *testing.T) {
+		in := "line1\nline2\rline3\t tab"
+		out := sanitizeForLog(in)
+		assert.NotContains(t, out, "\n")
+		assert.NotContains(t, out, "\r")
+		assert.NotContains(t, out, "\t")
+		assert.Equal(t, "line1 line2 line3   tab", out)
+	})
+
+	t.Run("truncates at maxCSPReportFieldLen runes and appends ellipsis", func(t *testing.T) {
+		in := strings.Repeat("a", maxCSPReportFieldLen+100)
+		out := sanitizeForLog(in)
+		assert.Equal(t, maxCSPReportFieldLen+3, len([]rune(out)), "output should be 500 runes + \"...\"")
+		assert.True(t, strings.HasSuffix(out, "..."))
+	})
+
+	t.Run("preserves short normal string", func(t *testing.T) {
+		in := "https://example.com/script.js"
+		assert.Equal(t, in, sanitizeForLog(in))
+	})
+
+	t.Run("replaces non-printable runes with space", func(t *testing.T) {
+		in := "foo\x00bar"
+		out := sanitizeForLog(in)
+		assert.Equal(t, "foo bar", out)
+	})
+
+	t.Run("empty string returns empty", func(t *testing.T) {
+		assert.Empty(t, sanitizeForLog(""))
+	})
+
+	t.Run("preserves Unicode runes", func(t *testing.T) {
+		in := "café résumé"
+		assert.Equal(t, in, sanitizeForLog(in))
+	})
+
+	t.Run("truncation does not split multi-byte rune", func(t *testing.T) {
+		// 501 runes: 500 'a' + 1 'é' (2 bytes in UTF-8). Truncate to 500 runes -> "aaa...aaa" no é.
+		in := strings.Repeat("a", maxCSPReportFieldLen) + "é"
+		out := sanitizeForLog(in)
+		assert.True(t, strings.HasSuffix(out, "..."), "should be truncated with ellipsis")
+		assert.LessOrEqual(t, len([]rune(out)), maxCSPReportFieldLen+3)
+	})
+}

--- a/server/jwt_test.go
+++ b/server/jwt_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -487,6 +488,29 @@ func TestValidateToken(t *testing.T) {
 				require.NotNil(t, validationErr)
 				assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 			}
+		})
+
+		// Security: alg "none" must always be rejected (algorithm confusion attack).
+		t.Run("alg none token rejected", func(t *testing.T) {
+			_, _, jwtKeyFunc := makeKeySet(t)
+			siteURL, _ := url.Parse(TestSiteURL)
+			expectedAud := fmt.Sprintf(ExpectedAudienceFmt, siteURL.Host, TestClientID)
+			header := []byte(`{"alg":"none","typ":"JWT"}`)
+			payload, _ := json.Marshal(map[string]interface{}{
+				"aud": expectedAud,
+				"exp": future(),
+				"iat": past(),
+				"nbf": past(),
+				"tid": "test-tenant-id",
+			})
+			b64Header := base64.RawURLEncoding.EncodeToString(header)
+			b64Payload := base64.RawURLEncoding.EncodeToString(payload)
+			tokenNone := b64Header + "." + b64Payload + "." // empty signature for alg "none"
+
+			params := makeValidateTokenParams(jwtKeyFunc, tokenNone, []string{"test-tenant-id"}, false)
+			_, validationErr := validateToken(params)
+			require.NotNil(t, validationErr, "alg none token must be rejected")
+			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 		})
 	})
 }


### PR DESCRIPTION
#### Summary

Improve CSP report logging and JWT validation tests

- Sanitize and truncate CSP report body fields before logging
- Add unit tests for the CSP sanitization helper
- Add TestValidateToken subtest to ensure alg "none" tokens are rejected

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-67466
