### PR TITLE
Update manifest to 1.22, update Community for Mattermost to 1.0.9

### DIFF
--- a/appstore/Community for Mattermost/manifest.json
+++ b/appstore/Community for Mattermost/manifest.json
@@ -1,7 +1,7 @@
 {
-   "$schema":"https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-   "version":"1.0.8",
-   "manifestVersion":"1.19",
+   "$schema":"https://developer.microsoft.com/en-us/json-schemas/teams/v1.22/MicrosoftTeams.schema.json",
+   "version":"1.0.9",
+   "manifestVersion":"1.22",
    "id":"b5f44ca1-af3f-4928-892f-63aa09d3527a",
    "name":{
       "short":"Community for Mattermost",

--- a/assets/appmanifest.json.tmpl
+++ b/assets/appmanifest.json.tmpl
@@ -1,7 +1,7 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.22/MicrosoftTeams.schema.json",
     "version": "{{.AppVersion}}",
-    "manifestVersion": "1.19",
+    "manifestVersion": "1.22",
     "id": "{{.AppID}}",
     "name": {
         "short": "{{.AppName}}",
@@ -62,7 +62,7 @@
     },
     "devicePermissions": [
         "media"
-    ],    
+    ],
     "defaultGroupCapability": {
         "team": "tab"
     },

--- a/build/custom.mk
+++ b/build/custom.mk
@@ -1,1 +1,27 @@
 # Include custom targets and environment variables here
+
+APPSTORE_DIR ?= appstore
+APPSTORE_DIST_DIR ?= dist/appstore
+
+## Build zip bundles for each app under $(APPSTORE_DIR), named <folder>-<version>.zip
+## where <version> is read from each folder's manifest.json `.version` field.
+.PHONY: appstore-bundles
+appstore-bundles:
+	@mkdir -p $(APPSTORE_DIST_DIR)
+	@find $(APPSTORE_DIR) -mindepth 1 -maxdepth 1 -type d | while IFS= read -r dir; do \
+		name=$$(basename "$$dir"); \
+		manifest="$$dir/manifest.json"; \
+		if [ ! -f "$$manifest" ]; then \
+			echo "Skipping $$name: missing manifest.json"; \
+			continue; \
+		fi; \
+		version=$$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$$manifest" | head -1); \
+		if [ -z "$$version" ]; then \
+			echo "Skipping $$name: no .version in manifest.json"; \
+			continue; \
+		fi; \
+		out="$$PWD/$(APPSTORE_DIST_DIR)/$$name-$$version.zip"; \
+		echo "Bundling $$name-$$version.zip"; \
+		rm -f "$$out"; \
+		(cd "$$dir" && zip -qr "$$out" . -x "*.zip") || exit $$?; \
+	done

--- a/build/custom.mk
+++ b/build/custom.mk
@@ -7,8 +7,9 @@ APPSTORE_DIST_DIR ?= dist/appstore
 ## where <version> is read from each folder's manifest.json `.version` field.
 .PHONY: appstore-bundles
 appstore-bundles:
-	@mkdir -p $(APPSTORE_DIST_DIR)
-	@find $(APPSTORE_DIR) -mindepth 1 -maxdepth 1 -type d | while IFS= read -r dir; do \
+	@mkdir -p "$(APPSTORE_DIST_DIR)"
+	@find "$(APPSTORE_DIST_DIR)" -maxdepth 1 -type f -name '*.zip' -delete
+	@find "$(APPSTORE_DIR)" -mindepth 1 -maxdepth 1 -type d | while IFS= read -r dir; do \
 		name=$$(basename "$$dir"); \
 		manifest="$$dir/manifest.json"; \
 		if [ ! -f "$$manifest" ]; then \
@@ -20,8 +21,11 @@ appstore-bundles:
 			echo "Skipping $$name: no .version in manifest.json"; \
 			continue; \
 		fi; \
+		if ! printf '%s' "$$version" | grep -Eq '^[A-Za-z0-9._-]+$$'; then \
+			echo "Skipping $$name: invalid version '$$version' for filename use"; \
+			continue; \
+		fi; \
 		out="$$PWD/$(APPSTORE_DIST_DIR)/$$name-$$version.zip"; \
 		echo "Bundling $$name-$$version.zip"; \
-		rm -f "$$out"; \
 		(cd "$$dir" && zip -qr "$$out" . -x "*.zip") || exit $$?; \
 	done

--- a/build/custom.mk
+++ b/build/custom.mk
@@ -7,6 +7,7 @@ APPSTORE_DIST_DIR ?= dist/appstore
 ## where <version> is read from each folder's manifest.json `.version` field.
 .PHONY: appstore-bundles
 appstore-bundles:
+	@command -v jq >/dev/null 2>&1 || { echo "appstore-bundles requires jq to be installed"; exit 1; }
 	@mkdir -p "$(APPSTORE_DIST_DIR)"
 	@find "$(APPSTORE_DIST_DIR)" -maxdepth 1 -type f -name '*.zip' -delete
 	@find "$(APPSTORE_DIR)" -mindepth 1 -maxdepth 1 -type d | while IFS= read -r dir; do \
@@ -16,7 +17,7 @@ appstore-bundles:
 			echo "Skipping $$name: missing manifest.json"; \
 			continue; \
 		fi; \
-		version=$$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$$manifest" | head -1); \
+		version=$$(jq -r '.version // empty' "$$manifest"); \
 		if [ -z "$$version" ]; then \
 			echo "Skipping $$name: no .version in manifest.json"; \
 			continue; \


### PR DESCRIPTION
#### Summary
- Bumped the `manifestVersion` for the plugin generated manifests to `1.22`
  - Same to the stored "Community for Mattermost" app present in `appstore/`
- Bumped "Community for Mattermost" to 1.0.9
- Added `make appstore-bundles` that automatically generate the ZIP files for the applications