### PR TITLE
Update Community for Mattermost manifest to 1.0.11

### DIFF
--- a/appstore/Community for Mattermost/manifest.json
+++ b/appstore/Community for Mattermost/manifest.json
@@ -1,54 +1,52 @@
 {
-   "$schema":"https://developer.microsoft.com/en-us/json-schemas/teams/v1.22/MicrosoftTeams.schema.json",
-   "version":"1.0.9",
-   "manifestVersion":"1.22",
-   "id":"b5f44ca1-af3f-4928-892f-63aa09d3527a",
-   "name":{
-      "short":"Community for Mattermost",
-      "full":"Community for Mattermost"
-   },
-   "developer":{
-      "name":"Mattermost",
-      "mpnId":"",
-      "websiteUrl":"https://mattermost.com/",
-      "privacyUrl":"https://mattermost.com/privacy-policy/",
-      "termsOfUseUrl":"https://mattermost.com/software-services-license-agreement/"
-   },
-   "description":{
-      "short":"Connect with the Community for Mattermost for seamless collaboration.",
-      "full":"The Community for Mattermost app for Microsoft 365 provides seamless access to the public Community for Mattermost instance from inside the tools you use every day. Join thousands of Mattermost users, contributors, and staff members in a vibrant community where you can ask questions, get support, share ideas, and contribute to shaping the future of Mattermost.\n\nKey Features:\n- Direct Access: Access the Community for Mattermost directly from a tab without switching applications or opening a browser\n- Seamless Integration: Experience the full functionality of Community for Mattermost within a familiar interface\n- Real-time Collaboration: Engage with the Community for Mattermost in real-time discussions on product features, technical questions, and best practices\n- Product Support: Get help from both Mattermost staff and experienced community members\n- Contribute to Development: Participate in discussions that shape the future direction of Mattermost products\n- Knowledge Sharing: Learn implementation strategies and best practices from a diverse community of users\n- Stay Updated: Keep up with the latest Mattermost announcements, updates, and roadmap information\n\nThis app is designed to work with Microsoft 365, Outlook and Microsoft Teams. A free account is required to use Community for Mattermost.\n\nAbout Mattermost: \nMattermost is a purpose-built platform for technical and operational teams working in organizations vital to national security, public safety and critical infrastructure. [https://mattermost.com/](https://mattermost.com/)"
-   },
-   "icons":{
-      "outline":"community-outline.png",
-      "color":"community-color.png"
-   },
-    "accentColor":"#1e325c",
-    "staticTabs":[
-       {
-          "entityId":"Community",
-          "name":"Community",
-          "contentUrl":"https://community.mattermost.com/plugins/com.mattermost.plugin-msteams-devsecops/iframe/mattermostTab",
-          "scopes":["personal"]
-       },
-       {
-         "entityId": "notification_preview",
-         "name": "Notification Preview",
-         "contentUrl": "https://community.mattermost.com/plugins/com.mattermost.plugin-msteams-devsecops/iframe/mattermostTab?action=notification_preview",
-         "scopes": ["personal"]
-       },       
-       {
-          "entityId":"about",
-          "scopes":["personal"]
-       }
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.22/MicrosoftTeams.schema.json",
+    "version": "1.0.11",
+    "manifestVersion": "1.22",
+    "id": "b5f44ca1-af3f-4928-892f-63aa09d3527a",
+    "name": {
+        "short": "Community for Mattermost",
+        "full": "Community for Mattermost"
+    },
+    "developer": {
+        "name": "Mattermost",
+        "mpnId": "",
+        "websiteUrl": "https://mattermost.com/",
+        "privacyUrl": "https://mattermost.com/privacy-policy/",
+        "termsOfUseUrl": "https://mattermost.com/software-services-license-agreement/"
+    },
+    "description": {
+        "short": "Connect with the Community for Mattermost for seamless collaboration.",
+        "full": "The Community for Mattermost app for Microsoft 365 provides seamless access to the public Community for Mattermost instance from inside the tools you use every day. Join thousands of Mattermost users, contributors, and staff members in a vibrant community where you can ask questions, get support, share ideas, and contribute to shaping the future of Mattermost.\n\nKey Features:\n- Direct Access: Access the Community for Mattermost directly from a tab without switching applications or opening a browser\n- Seamless Integration: Experience the full functionality of Community for Mattermost within a familiar interface\n- Real-time Collaboration: Engage with the Community for Mattermost in real-time discussions on product features, technical questions, and best practices\n- Product Support: Get help from both Mattermost staff and experienced community members\n- Contribute to Development: Participate in discussions that shape the future direction of Mattermost products\n- Knowledge Sharing: Learn implementation strategies and best practices from a diverse community of users\n- Stay Updated: Keep up with the latest Mattermost announcements, updates, and roadmap information\n\nThis app is designed to work with Microsoft 365, Outlook and Microsoft Teams. A free account is required to use Community for Mattermost.\n\nAbout Mattermost: \nMattermost is a purpose-built platform for technical and operational teams working in organizations vital to national security, public safety and critical infrastructure. [https://mattermost.com/](https://mattermost.com/)"
+    },
+    "icons": {
+        "outline": "community-outline.png",
+        "color": "community-color.png"
+    },
+    "accentColor": "#1e325c",
+    "staticTabs": [
+        {
+            "entityId": "Community",
+            "name": "Community",
+            "contentUrl": "https://community.mattermost.com/plugins/com.mattermost.plugin-msteams-devsecops/iframe/mattermostTab",
+            "scopes": ["personal"]
+        },
+        {
+            "entityId": "notification_preview",
+            "name": "Notification Preview",
+            "contentUrl": "https://community.mattermost.com/plugins/com.mattermost.plugin-msteams-devsecops/iframe/mattermostTab?action=notification_preview",
+            "scopes": ["personal"]
+        },
+        {
+            "entityId": "about",
+            "scopes": ["personal"]
+        }
     ],
-    "validDomains":[
-       "community.mattermost.com"
-    ],
+    "validDomains": ["community.mattermost.com"],
     "showLoadingIndicator": false,
-    "isFullScreen": true,    
-    "webApplicationInfo":{
-       "id":"6717098f-f214-44b6-b537-3f1a0fdca421",
-       "resource":"api://community.mattermost.com/6717098f-f214-44b6-b537-3f1a0fdca421"
+    "isFullScreen": true,
+    "webApplicationInfo": {
+        "id": "6717098f-f214-44b6-b537-3f1a0fdca421",
+        "resource": "api://community.mattermost.com/6717098f-f214-44b6-b537-3f1a0fdca421"
     },
     "authorization": {
         "permissions": {
@@ -58,21 +56,19 @@
                     "type": "Application"
                 }
             ]
-        }    
+        }
     },
-    "devicePermissions": [
-        "media"
-    ],    
-    "defaultGroupCapability":{
-       "team": "tab"
+    "devicePermissions": ["media"],
+    "defaultGroupCapability": {
+        "team": "tab"
     },
     "activities": {
-       "activityTypes": [
-          {
-          "type": "mattermost_mention_with_name",
-          "description": "New message in Mattermost for the Teams user",
-          "templateText": "{post_author} mentioned you in Mattermost."
-          }
-       ]
-    }    
- }
+        "activityTypes": [
+            {
+                "type": "mattermost_mention_with_name",
+                "description": "New message in Mattermost for the Teams user",
+                "templateText": "{post_author} mentioned you in Mattermost."
+            }
+        ]
+    }
+}

--- a/appstore/Community for Mattermost/manifest.json
+++ b/appstore/Community for Mattermost/manifest.json
@@ -59,9 +59,6 @@
         }
     },
     "devicePermissions": ["media"],
-    "defaultGroupCapability": {
-        "team": "tab"
-    },
     "activities": {
         "activityTypes": [
             {

--- a/assets/appmanifest.json.tmpl
+++ b/assets/appmanifest.json.tmpl
@@ -26,7 +26,7 @@
     "staticTabs": [
         {
             "entityId": "Mattermost",
-            "name": "Mattermost",
+            "name": "{{.AppName}}",
             "contentUrl": "https://{{.SiteDomainPath}}/plugins/{{.PluginID}}/iframe/mattermostTab",
             "scopes": ["personal"]
         },
@@ -63,9 +63,6 @@
     "devicePermissions": [
         "media"
     ],
-    "defaultGroupCapability": {
-        "team": "tab"
-    },
     "activities": {
         "activityTypes": [
             {

--- a/assets/iframe.html.tmpl
+++ b/assets/iframe.html.tmpl
@@ -33,10 +33,20 @@
       const iframe = document.querySelector('iframe');
 
       function errorToString(error) {
-        if (!error) return 'Unknown error';
-        if (typeof error === 'string') return error;
-        if (error.message) return String(error.message);
-        try { return String(JSON.stringify(error)); } catch (_) { return String(error); }
+        if (!error) {
+          return 'Unknown error';
+        }
+        if (typeof error === 'string') {
+          return error;
+        }
+        if (error.message) {
+          return String(error.message);
+        }
+        try {
+          return String(JSON.stringify(error));
+        } catch (_) {
+          return String(error);
+        }
       }
 
       function isValidOrigin(eventOrigin, expectedOrigin) {

--- a/assets/iframe.html.tmpl
+++ b/assets/iframe.html.tmpl
@@ -35,8 +35,8 @@
       function errorToString(error) {
         if (!error) return 'Unknown error';
         if (typeof error === 'string') return error;
-        if (error.message) return error.message;
-        try { return JSON.stringify(error); } catch (_) { return String(error); }
+        if (error.message) return String(error.message);
+        try { return String(JSON.stringify(error)); } catch (_) { return String(error); }
       }
 
       function isValidOrigin(eventOrigin, expectedOrigin) {

--- a/assets/iframe.html.tmpl
+++ b/assets/iframe.html.tmpl
@@ -125,7 +125,7 @@
               if (retries < maxRetries) {
                 console.log("Retrying...");
                 retries++;
-                setTimeout(getToken, 250 + (250 * retries^2)); // Exponential backoff
+                setTimeout(getToken, 250 + (250 * retries * retries)); // Exponential backoff
               } else {
                 reject(errorToString(error));
               }

--- a/assets/iframe.html.tmpl
+++ b/assets/iframe.html.tmpl
@@ -6,8 +6,8 @@
   <title>Mattermost DevSecOps</title>
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0">
   <script
-    src="https://res.cdn.office.net/teams-js/2.34.0/js/MicrosoftTeams.min.js"
-    integrity="sha384-brW9AazbKR2dYw2DucGgWCCcmrm2oBFV4HQidyuyZRI/TnAkmOOnTARSTdps3Hwt"
+    src="https://res.cdn.office.net/teams-js/2.53.0/js/MicrosoftTeams.min.js"
+    integrity="sha384-UFKwOGC8ix6vOFFC4vH8hSpjwkQXZmSjCx8aaxwhbtm+6joQdNvD7b4pPk82cYAD"
     crossorigin="anonymous"
   ></script>
 </head>
@@ -32,6 +32,13 @@
       const domainRoot = '{{.SiteURL}}';
       const iframe = document.querySelector('iframe');
 
+      function errorToString(error) {
+        if (!error) return 'Unknown error';
+        if (typeof error === 'string') return error;
+        if (error.message) return error.message;
+        try { return JSON.stringify(error); } catch (_) { return String(error); }
+      }
+
       function isValidOrigin(eventOrigin, expectedOrigin) {
         try {
           const eventUrl = new URL(eventOrigin);
@@ -41,7 +48,7 @@
           eventUrl.hostname === expectedUrl.hostname &&
           eventUrl.port === expectedUrl.port;
         } catch (e) {
-          console.error('Invalid origin URL:', e);
+          console.error('Invalid origin URL:', errorToString(e));
           return false;
         }
       }
@@ -82,7 +89,7 @@
           }).catch((error) => {
             waitIframeWindow.postMessage({
               type: 'auth_error',
-              error: error ? (error.message || String(error)) : 'Authentication failed'
+              error: errorToString(error) || 'Authentication failed'
             }, domainRoot);
           })
         }
@@ -103,13 +110,14 @@
             microsoftTeams.authentication.getAuthToken().then((token) => {
               resolve(token);
             }).catch((error) => {
-              console.error("Failed to get token:", error);
+              console.error("Failed to get token:", errorToString(error));
+              console.error(error); // Fallback to regular console.error in case the error coming from teams it's not a string
               if (retries < maxRetries) {
                 console.log("Retrying...");
                 retries++;
                 setTimeout(getToken, 250 + (250 * retries^2)); // Exponential backoff
               } else {
-                reject(error);
+                reject(errorToString(error));
               }
             });
           };
@@ -121,7 +129,8 @@
       microsoftTeams.app.initialize(['{{.SiteURL}}']).then(() => {
         microsoftTeams.app.notifySuccess();
       }).catch((error) => {
-        console.error('Failed to initialize Microsoft Teams SDK:', error);
+        console.error('Failed to initialize Microsoft Teams SDK:', errorToString(error));
+        console.error(error);
         iframe.src = '{{.SiteURL}}';
       });
 
@@ -148,7 +157,7 @@
               iframe.src = `${domainRoot}/plugins/{{.PluginID}}/iframe/authenticate?${params.toString()}`;
             })
             .catch((error) => {
-              console.error('Failed to get auth token:', error);
+              console.error('Failed to get auth token:', errorToString(error));
               iframe.src = domainRoot;
             });
         } else {
@@ -160,7 +169,7 @@
       }).catch((error) => {
         // User appears to not be logged into Microsoft Teams, or the context is not available.
         // Just redirect to the SITE_URL and the user will have to log in without SSO.
-        console.error('Failed to get context:', error);
+        console.error('Failed to get context:', errorToString(error));
         iframe.src = '{{.SiteURL}}';
       });
     })(microsoftTeams);

--- a/webapp/src/errorToString.test.js
+++ b/webapp/src/errorToString.test.js
@@ -1,0 +1,78 @@
+// Tests for the errorToString utility used in assets/iframe.html.tmpl.
+// The function is inlined in the template (no module system); keep both in sync.
+function errorToString(error) {
+    if (!error) return 'Unknown error';
+    if (typeof error === 'string') return error;
+    if (error.message) return error.message;
+    try { return JSON.stringify(error); } catch (_) { return String(error); }
+}
+
+describe('errorToString', () => {
+    describe('falsy inputs', () => {
+        test('null returns Unknown error', () => {
+            expect(errorToString(null)).toBe('Unknown error');
+        });
+
+        test('undefined returns Unknown error', () => {
+            expect(errorToString(undefined)).toBe('Unknown error');
+        });
+
+        test('false returns Unknown error', () => {
+            expect(errorToString(false)).toBe('Unknown error');
+        });
+
+        test('0 returns Unknown error', () => {
+            expect(errorToString(0)).toBe('Unknown error');
+        });
+
+        test('empty string returns Unknown error', () => {
+            expect(errorToString('')).toBe('Unknown error');
+        });
+    });
+
+    describe('string inputs', () => {
+        test('plain string is returned as-is', () => {
+            expect(errorToString('something went wrong')).toBe('something went wrong');
+        });
+
+        test('Teams SDK error codes like CancelledByUser are returned as-is', () => {
+            expect(errorToString('CancelledByUser')).toBe('CancelledByUser');
+        });
+    });
+
+    describe('Error objects', () => {
+        test('Error instance returns its message', () => {
+            expect(errorToString(new Error('test error'))).toBe('test error');
+        });
+
+        test('Error with empty message falls through to JSON.stringify', () => {
+            const e = new Error('');
+            // Error.message is '' which is falsy, so falls through to JSON.stringify.
+            // JSON.stringify(new Error('')) returns '{}'.
+            expect(errorToString(e)).toBe('{}');
+        });
+    });
+
+    describe('plain objects', () => {
+        test('object with message property returns the message', () => {
+            expect(errorToString({ message: 'auth failed', code: 42 })).toBe('auth failed');
+        });
+
+        test('object without message is JSON-serialised', () => {
+            expect(errorToString({ code: 'TOKEN_EXPIRED' })).toBe('{"code":"TOKEN_EXPIRED"}');
+        });
+
+        test('empty object returns {}', () => {
+            expect(errorToString({})).toBe('{}');
+        });
+    });
+
+    describe('non-serialisable objects', () => {
+        test('circular-reference object falls back to String()', () => {
+            const circular = {};
+            circular.self = circular;
+            // JSON.stringify throws; String({}) => '[object Object]'
+            expect(errorToString(circular)).toBe('[object Object]');
+        });
+    });
+});

--- a/webapp/src/errorToString.test.js
+++ b/webapp/src/errorToString.test.js
@@ -11,10 +11,10 @@ function errorToString(error) {
         return error;
     }
     if (error.message) {
-        return error.message;
+        return String(error.message);
     }
     try {
-        return JSON.stringify(error);
+        return String(JSON.stringify(error));
     } catch (_) {
         return String(error);
     }

--- a/webapp/src/errorToString.test.js
+++ b/webapp/src/errorToString.test.js
@@ -114,7 +114,7 @@ describe('sync with assets/iframe.html.tmpl', () => {
 
         // Extract from template: function ends at the first `}` that sits at
         // the 6-space indentation level (the function's own closing brace).
-        const tmplMatch = tmpl.match(/function errorToString\(error\) \{[\s\S]*?\n      \}/);
+        const tmplMatch = tmpl.match(/function errorToString\(error\) \{[\s\S]*?\n {6}\}/);
 
         // Extract from this file: function ends at the first `}` at column 0.
         const testMatch = testSrc.match(/^function errorToString\(error\) \{[\s\S]*?^\}/m);

--- a/webapp/src/errorToString.test.js
+++ b/webapp/src/errorToString.test.js
@@ -1,10 +1,23 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 // Tests for the errorToString utility used in assets/iframe.html.tmpl.
 // The function is inlined in the template (no module system); keep both in sync.
 function errorToString(error) {
-    if (!error) return 'Unknown error';
-    if (typeof error === 'string') return error;
-    if (error.message) return error.message;
-    try { return JSON.stringify(error); } catch (_) { return String(error); }
+    if (!error) {
+        return 'Unknown error';
+    }
+    if (typeof error === 'string') {
+        return error;
+    }
+    if (error.message) {
+        return error.message;
+    }
+    try {
+        return JSON.stringify(error);
+    } catch (_) {
+        return String(error);
+    }
 }
 
 describe('errorToString', () => {
@@ -47,6 +60,7 @@ describe('errorToString', () => {
 
         test('Error with empty message falls through to JSON.stringify', () => {
             const e = new Error('');
+
             // Error.message is '' which is falsy, so falls through to JSON.stringify.
             // JSON.stringify(new Error('')) returns '{}'.
             expect(errorToString(e)).toBe('{}');
@@ -55,11 +69,11 @@ describe('errorToString', () => {
 
     describe('plain objects', () => {
         test('object with message property returns the message', () => {
-            expect(errorToString({ message: 'auth failed', code: 42 })).toBe('auth failed');
+            expect(errorToString({message: 'auth failed', code: 42})).toBe('auth failed');
         });
 
         test('object without message is JSON-serialised', () => {
-            expect(errorToString({ code: 'TOKEN_EXPIRED' })).toBe('{"code":"TOKEN_EXPIRED"}');
+            expect(errorToString({code: 'TOKEN_EXPIRED'})).toBe('{"code":"TOKEN_EXPIRED"}');
         });
 
         test('empty object returns {}', () => {
@@ -71,6 +85,7 @@ describe('errorToString', () => {
         test('circular-reference object falls back to String()', () => {
             const circular = {};
             circular.self = circular;
+
             // JSON.stringify throws; String({}) => '[object Object]'
             expect(errorToString(circular)).toBe('[object Object]');
         });

--- a/webapp/src/errorToString.test.js
+++ b/webapp/src/errorToString.test.js
@@ -1,6 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+const fs = require('fs');
+const path = require('path');
+
 // Tests for the errorToString utility used in assets/iframe.html.tmpl.
 // The function is inlined in the template (no module system); keep both in sync.
 function errorToString(error) {
@@ -89,5 +92,35 @@ describe('errorToString', () => {
             // JSON.stringify throws; String({}) => '[object Object]'
             expect(errorToString(circular)).toBe('[object Object]');
         });
+    });
+});
+
+describe('sync with assets/iframe.html.tmpl', () => {
+    // Collapse all whitespace so indentation differences between the template
+    // (6-space indent) and this file (4-space indent) do not cause false failures.
+    function normalize(src) {
+        return src.replace(/\s+/g, ' ').trim();
+    }
+
+    test('errorToString body matches the copy inlined in the template', () => {
+        const tmpl = fs.readFileSync(
+            path.resolve(__dirname, '../../assets/iframe.html.tmpl'),
+            'utf8',
+        );
+
+        // Read the source of this file directly so we compare raw text,
+        // not the Babel-transpiled output of Function.prototype.toString().
+        const testSrc = fs.readFileSync(__filename, 'utf8');
+
+        // Extract from template: function ends at the first `}` that sits at
+        // the 6-space indentation level (the function's own closing brace).
+        const tmplMatch = tmpl.match(/function errorToString\(error\) \{[\s\S]*?\n      \}/);
+
+        // Extract from this file: function ends at the first `}` at column 0.
+        const testMatch = testSrc.match(/^function errorToString\(error\) \{[\s\S]*?^\}/m);
+
+        expect(tmplMatch).not.toBeNull();
+        expect(testMatch).not.toBeNull();
+        expect(normalize(tmplMatch[0])).toBe(normalize(testMatch[0]));
     });
 });


### PR DESCRIPTION
## Summary
- Bump Community for Mattermost manifest version from 1.0.9 to 1.0.11
- Remove unused `defaultGroupCapability` from both manifests (app has only personal-scoped tabs, so this field had no effect)
- Fix static tab name to use `{{.AppName}}` template variable instead of hard-coded `"Mattermost"`
- Add `errorToString()` helper in `iframe.html.tmpl` to prevent `[object Object]` surfacing in auth error messages — applies to all `catch` blocks and `postMessage` payloads
- Add Jest tests for `errorToString` covering null/undefined, strings, `Error` instances, plain objects, and circular references