### PR TITLE
Fix azure-setup create failures in dry-run and API exposure PATCH

### DIFF
--- a/cmd/azure-setup/app.go
+++ b/cmd/azure-setup/app.go
@@ -39,6 +39,8 @@ func createApplication(ctx context.Context, client *msgraphsdk.GraphServiceClien
 		mockApp.SetDisplayName(&displayName)
 		appID := "00000000-0000-0000-0000-000000000000"
 		mockApp.SetAppId(&appID)
+		objectID := "00000000-0000-0000-0000-000000000000"
+		mockApp.SetId(&objectID)
 		return mockApp, nil
 	}
 

--- a/cmd/azure-setup/expose.go
+++ b/cmd/azure-setup/expose.go
@@ -36,14 +36,6 @@ func configureAPIExposure(ctx context.Context, client *msgraphsdk.GraphServiceCl
 		return nil
 	}
 
-	// Create the api configuration
-	api := models.NewApiApplication()
-
-	// Set the Application ID URI (identifier)
-	identifierUris := []string{appIDURI}
-	appUpdate := models.NewApplication()
-	appUpdate.SetIdentifierUris(identifierUris)
-
 	// Create the access_as_user scope
 	scopeID := uuid.New()
 	scope := models.NewPermissionScope()
@@ -71,21 +63,44 @@ func configureAPIExposure(ctx context.Context, client *msgraphsdk.GraphServiceCl
 	scope.SetIsEnabled(&isEnabled)
 
 	oauth2PermissionScopes := []models.PermissionScopeable{scope}
-	api.SetOauth2PermissionScopes(oauth2PermissionScopes)
 
-	// Add pre-authorized applications
+	// PATCH 1: Set the Application ID URI and the OAuth2 permission scope.
+	// Microsoft Graph validates preAuthorizedApplications.delegatedPermissionIds
+	// against the application's existing OAuth2PermissionScopes (the pre-PATCH
+	// state), so the scope must exist on the application BEFORE we can reference
+	// it in preAuthorizedApplications. Doing this in a single PATCH triggers:
+	// "Property api.preAuthorizedApplications.delegatedPermissionIds has a
+	// Permission Id that cannot be found in the AppPermissions sets."
+	identifierUris := []string{appIDURI}
+	apiStep1 := models.NewApiApplication()
+	apiStep1.SetOauth2PermissionScopes(oauth2PermissionScopes)
+
+	appUpdateStep1 := models.NewApplication()
+	appUpdateStep1.SetIdentifierUris(identifierUris)
+	appUpdateStep1.SetApi(apiStep1)
+
+	if _, err = client.Applications().ByApplicationId(*app.GetId()).Patch(ctx, appUpdateStep1, nil); err != nil {
+		return errors.Wrapf(err, "failed to configure API scope (scope ID: %s, value: %s)", scopeID.String(), ScopeName)
+	}
+
+	// PATCH 2: Add pre-authorized applications referencing the scope created above.
+	// We re-send oauth2PermissionScopes to preserve it — PATCH semantics on the
+	// nested `api` complex type can otherwise wipe the scopes we just set.
 	preAuthorizedApps, err := buildPreAuthorizedApplications(scopeID)
 	if err != nil {
 		return err
 	}
-	api.SetPreAuthorizedApplications(preAuthorizedApps)
 
-	appUpdate.SetApi(api)
+	apiStep2 := models.NewApiApplication()
+	apiStep2.SetOauth2PermissionScopes(oauth2PermissionScopes)
+	apiStep2.SetPreAuthorizedApplications(preAuthorizedApps)
 
-	// Update the application
-	_, err = client.Applications().ByApplicationId(*app.GetId()).Patch(ctx, appUpdate, nil)
-	if err != nil {
-		return errors.Wrap(err, "failed to configure API exposure")
+	appUpdateStep2 := models.NewApplication()
+	appUpdateStep2.SetApi(apiStep2)
+
+	if _, err = client.Applications().ByApplicationId(*app.GetId()).Patch(ctx, appUpdateStep2, nil); err != nil {
+		preAuthClientIDs := getPreAuthorizedClients()
+		return errors.Wrapf(err, "failed to configure pre-authorized applications (delegated permission scope ID: %s, value: %s, pre-authorized client IDs: %v)", scopeID.String(), ScopeName, preAuthClientIDs)
 	}
 
 	if config.Verbose {


### PR DESCRIPTION
## Summary

Two bug fixes in the `azure-setup` CLI surfaced while running `create`:

- **Dry-run nil pointer panic**: `createApplication` built a mock app without an `Id`, so `executeSetup`'s `*app.GetId()` panicked when building the result. Now sets a placeholder `Id` alongside `AppId`.
- **API exposure PATCH rejected by Microsoft Graph**: `configureAPIExposure` set the new `OAuth2PermissionScopes` and the `PreAuthorizedApplications` referencing them in a single PATCH. Graph validates `delegatedPermissionIds` against the **existing** scope set (pre-PATCH state), so it failed with `Property api.preAuthorizedApplications.delegatedPermissionIds has a Permission Id that cannot be found in the AppPermissions sets.` The update is now split into two PATCHes: first create the scope, then add the pre-authorized apps. Both error paths are enriched with the scope ID, scope value, and pre-authorized client IDs to make any future Graph rejection debuggable.
