### PR TITLE
MM-69072: Make configureAPIExposure idempotent to avoid duplicate scopes

### DIFF
--- a/cmd/azure-setup/expose.go
+++ b/cmd/azure-setup/expose.go
@@ -36,8 +36,12 @@ func configureAPIExposure(ctx context.Context, client *msgraphsdk.GraphServiceCl
 		return nil
 	}
 
-	// Create the access_as_user scope
-	scopeID := uuid.New()
+	// Reuse the existing scope ID to keep re-runs idempotent; only mint a new
+	// UUID when no access_as_user scope exists yet.
+	scopeID := findExistingScopeID(app)
+	if scopeID == uuid.Nil {
+		scopeID = uuid.New()
+	}
 	scope := models.NewPermissionScope()
 	scope.SetId(&scopeID)
 
@@ -115,6 +119,21 @@ func configureAPIExposure(ctx context.Context, client *msgraphsdk.GraphServiceCl
 	}
 
 	return nil
+}
+
+// findExistingScopeID returns the UUID of the existing access_as_user scope on the
+// app, or uuid.Nil if none is found. Used to avoid generating a duplicate scope ID
+// when configureAPIExposure is called against an already-configured application.
+func findExistingScopeID(app models.Applicationable) uuid.UUID {
+	if app.GetApi() == nil {
+		return uuid.Nil
+	}
+	for _, scope := range app.GetApi().GetOauth2PermissionScopes() {
+		if scope.GetValue() != nil && *scope.GetValue() == ScopeName && scope.GetId() != nil {
+			return *scope.GetId()
+		}
+	}
+	return uuid.Nil
 }
 
 // buildPreAuthorizedApplications creates the list of pre-authorized applications

--- a/cmd/azure-setup/expose_test.go
+++ b/cmd/azure-setup/expose_test.go
@@ -185,6 +185,64 @@ func TestConfigureAPIExposure_VerboseOutput(t *testing.T) {
 	require.NoError(t, err, "Verbose mode should not affect success")
 }
 
+// TestFindExistingScopeID tests scope ID lookup on existing app objects
+func TestFindExistingScopeID(t *testing.T) {
+	t.Run("returns_nil_when_api_is_nil", func(t *testing.T) {
+		app := models.NewApplication()
+		assert.Equal(t, uuid.Nil, findExistingScopeID(app))
+	})
+
+	t.Run("returns_nil_when_no_scopes", func(t *testing.T) {
+		app := models.NewApplication()
+		api := models.NewApiApplication()
+		api.SetOauth2PermissionScopes([]models.PermissionScopeable{})
+		app.SetApi(api)
+		assert.Equal(t, uuid.Nil, findExistingScopeID(app))
+	})
+
+	t.Run("returns_nil_when_scope_name_does_not_match", func(t *testing.T) {
+		app := models.NewApplication()
+		api := models.NewApiApplication()
+		scope := models.NewPermissionScope()
+		otherName := "other_scope"
+		otherID := uuid.New()
+		scope.SetValue(&otherName)
+		scope.SetId(&otherID)
+		api.SetOauth2PermissionScopes([]models.PermissionScopeable{scope})
+		app.SetApi(api)
+		assert.Equal(t, uuid.Nil, findExistingScopeID(app))
+	})
+
+	t.Run("returns_existing_scope_id", func(t *testing.T) {
+		existingID := uuid.New()
+		app := models.NewApplication()
+		api := models.NewApiApplication()
+		scope := models.NewPermissionScope()
+		scopeName := ScopeName
+		scope.SetValue(&scopeName)
+		scope.SetId(&existingID)
+		api.SetOauth2PermissionScopes([]models.PermissionScopeable{scope})
+		app.SetApi(api)
+		assert.Equal(t, existingID, findExistingScopeID(app))
+	})
+
+	t.Run("reuses_id_not_uuid_nil_when_scope_present", func(t *testing.T) {
+		existingID := uuid.New()
+		app := models.NewApplication()
+		api := models.NewApiApplication()
+		scope := models.NewPermissionScope()
+		scopeName := ScopeName
+		scope.SetValue(&scopeName)
+		scope.SetId(&existingID)
+		api.SetOauth2PermissionScopes([]models.PermissionScopeable{scope})
+		app.SetApi(api)
+
+		result := findExistingScopeID(app)
+		assert.NotEqual(t, uuid.Nil, result)
+		assert.Equal(t, existingID, result)
+	})
+}
+
 // TestBuildPreAuthorizedApplications_ErrorHandling tests error scenarios
 func TestBuildPreAuthorizedApplications_ErrorHandling(t *testing.T) {
 	t.Run("valid_uuid_scope", func(t *testing.T) {

--- a/cmd/azure-setup/validate.go
+++ b/cmd/azure-setup/validate.go
@@ -169,6 +169,7 @@ func checkExistingApp(ctx context.Context, client *msgraphsdk.GraphServiceClient
 	apps, err := client.Applications().Get(ctx, &applications.ApplicationsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &applications.ApplicationsRequestBuilderGetQueryParameters{
 			Filter: &filter,
+			Select: []string{"id", "appId", "displayName", "api", "identifierUris"},
 		},
 	})
 	if err != nil {

--- a/cmd/azure-setup/validate.go
+++ b/cmd/azure-setup/validate.go
@@ -169,7 +169,7 @@ func checkExistingApp(ctx context.Context, client *msgraphsdk.GraphServiceClient
 	apps, err := client.Applications().Get(ctx, &applications.ApplicationsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &applications.ApplicationsRequestBuilderGetQueryParameters{
 			Filter: &filter,
-			Select: []string{"id", "appId", "displayName", "api", "identifierUris"},
+			Select: []string{"id", "appId", "displayName", "api", "identifierUris", "signInAudience"},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Root cause:** `configureAPIExposure` called `uuid.New()` unconditionally, so re-running against an already-configured app created a duplicate `access_as_user` scope with a different UUID on every invocation.
- **Fix:** Add `findExistingScopeID` which scans the existing app's `api.oauth2PermissionScopes` for `access_as_user` and returns its UUID. `configureAPIExposure` now reuses that ID when found, minting a fresh UUID only for first-time setup. Both PATCH 1 and PATCH 2 use the same stable ID, so re-runs converge.
- **Data loading:** Add `$select=id,appId,displayName,api,identifierUris` to `checkExistingApp` so the `api` complex property (including scopes) is explicitly requested from Graph, making the idempotency check reliable regardless of tenant defaults.

**Note on end-to-end verification:** The fix is correct by construction — `findExistingScopeID` is unit-tested against all cases (nil api, empty scopes, wrong name, matching name), and the scope ID flows consistently through both PATCHes. The assumption that Graph returns `api.oauth2PermissionScopes` on the listed app object is supported by the spec (`api` is a structural/complex property, not a navigation link, so `$select=api` returns the full value). Full convergence against a live tenant has not been manually verified in this PR.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-69072
