### PR TITLE
MM-69380: Add Microsoft national cloud support (GCC High and DoD)

### DIFF
--- a/cmd/azure-setup/auth.go
+++ b/cmd/azure-setup/auth.go
@@ -11,17 +11,19 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
 )
 
 // authenticateToAzure establishes authentication to Azure using available methods
 // Priority order: Environment variables -> Azure CLI -> Interactive browser
-func authenticateToAzure(ctx context.Context, tenantID string, verbose bool) (azcore.TokenCredential, error) {
+func authenticateToAzure(ctx context.Context, env cloudenv.Environment, tenantID string, verbose bool) (azcore.TokenCredential, error) {
 	if verbose {
 		fmt.Println("🔐 Authenticating to Azure...")
 	}
 
 	// Try multiple authentication methods in order of preference
-	credential, method, err := tryAuthenticationMethods(ctx, tenantID, verbose)
+	credential, method, err := tryAuthenticationMethods(ctx, env, tenantID, verbose)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to authenticate to Azure")
 	}
@@ -34,13 +36,13 @@ func authenticateToAzure(ctx context.Context, tenantID string, verbose bool) (az
 }
 
 // tryAuthenticationMethods attempts different authentication methods
-func tryAuthenticationMethods(ctx context.Context, tenantID string, verbose bool) (azcore.TokenCredential, string, error) {
+func tryAuthenticationMethods(ctx context.Context, env cloudenv.Environment, tenantID string, verbose bool) (azcore.TokenCredential, string, error) {
 	// Method 1: Try environment variables (service principal)
 	if verbose {
 		fmt.Println("   Trying: Environment variables (Service Principal)...")
 	}
-	if cred, err := tryEnvironmentCredential(tenantID); err == nil {
-		if err := testCredential(ctx, cred); err == nil {
+	if cred, err := tryEnvironmentCredential(env); err == nil {
+		if err := testCredential(ctx, env, cred); err == nil {
 			return cred, "Environment Variables (Service Principal)", nil
 		}
 	}
@@ -50,7 +52,7 @@ func tryAuthenticationMethods(ctx context.Context, tenantID string, verbose bool
 		fmt.Println("   Trying: Azure CLI...")
 	}
 	if cred, err := tryAzureCLICredential(tenantID); err == nil {
-		if err := testCredential(ctx, cred); err == nil {
+		if err := testCredential(ctx, env, cred); err == nil {
 			return cred, "Azure CLI", nil
 		}
 	}
@@ -59,8 +61,8 @@ func tryAuthenticationMethods(ctx context.Context, tenantID string, verbose bool
 	if verbose {
 		fmt.Println("   Trying: Interactive browser...")
 	}
-	if cred, err := tryInteractiveBrowserCredential(tenantID); err == nil {
-		if err := testCredential(ctx, cred); err == nil {
+	if cred, err := tryInteractiveBrowserCredential(env, tenantID); err == nil {
+		if err := testCredential(ctx, env, cred); err == nil {
 			return cred, "Interactive Browser", nil
 		}
 	}
@@ -69,8 +71,8 @@ func tryAuthenticationMethods(ctx context.Context, tenantID string, verbose bool
 	if verbose {
 		fmt.Println("   Trying: Device code flow...")
 	}
-	if cred, err := tryDeviceCodeCredential(tenantID); err == nil {
-		if err := testCredential(ctx, cred); err == nil {
+	if cred, err := tryDeviceCodeCredential(env, tenantID); err == nil {
+		if err := testCredential(ctx, env, cred); err == nil {
 			return cred, "Device Code Flow", nil
 		}
 	}
@@ -80,10 +82,13 @@ func tryAuthenticationMethods(ctx context.Context, tenantID string, verbose bool
 
 // tryEnvironmentCredential attempts to authenticate using environment variables.
 // EnvironmentCredential reads tenant configuration from AZURE_TENANT_ID and does
-// not expose AdditionallyAllowedTenants via options, so the tenantID parameter
-// is intentionally unused here.
-func tryEnvironmentCredential(_ string) (azcore.TokenCredential, error) {
-	cred, err := azidentity.NewEnvironmentCredential(nil)
+// not expose AdditionallyAllowedTenants via options, so no tenantID parameter is
+// accepted here. The national cloud is applied via ClientOptions.Cloud.
+func tryEnvironmentCredential(env cloudenv.Environment) (azcore.TokenCredential, error) {
+	opts := &azidentity.EnvironmentCredentialOptions{}
+	opts.Cloud = env.AzureCloud
+
+	cred, err := azidentity.NewEnvironmentCredential(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +96,10 @@ func tryEnvironmentCredential(_ string) (azcore.TokenCredential, error) {
 	return cred, nil
 }
 
-// tryAzureCLICredential attempts to authenticate using Azure CLI
+// tryAzureCLICredential attempts to authenticate using Azure CLI.
+// AzureCLICredentialOptions does not expose a cloud setting: the Azure CLI
+// credential inherits whatever cloud the operator has selected via
+// `az cloud set` (e.g. `az cloud set --name AzureUSGovernment` for GCC High/DoD).
 func tryAzureCLICredential(tenantID string) (azcore.TokenCredential, error) {
 	opts := &azidentity.AzureCLICredentialOptions{}
 	if tenantID != "" {
@@ -107,8 +115,9 @@ func tryAzureCLICredential(tenantID string) (azcore.TokenCredential, error) {
 }
 
 // tryInteractiveBrowserCredential attempts to authenticate using interactive browser
-func tryInteractiveBrowserCredential(tenantID string) (azcore.TokenCredential, error) {
+func tryInteractiveBrowserCredential(env cloudenv.Environment, tenantID string) (azcore.TokenCredential, error) {
 	opts := &azidentity.InteractiveBrowserCredentialOptions{}
+	opts.Cloud = env.AzureCloud
 	if tenantID != "" {
 		opts.TenantID = tenantID
 	}
@@ -122,13 +131,14 @@ func tryInteractiveBrowserCredential(tenantID string) (azcore.TokenCredential, e
 }
 
 // tryDeviceCodeCredential attempts to authenticate using device code flow
-func tryDeviceCodeCredential(tenantID string) (azcore.TokenCredential, error) {
+func tryDeviceCodeCredential(env cloudenv.Environment, tenantID string) (azcore.TokenCredential, error) {
 	opts := &azidentity.DeviceCodeCredentialOptions{
 		UserPrompt: func(ctx context.Context, message azidentity.DeviceCodeMessage) error {
 			fmt.Println("\n" + message.Message)
 			return nil
 		},
 	}
+	opts.Cloud = env.AzureCloud
 	if tenantID != "" {
 		opts.TenantID = tenantID
 	}
@@ -142,23 +152,23 @@ func tryDeviceCodeCredential(tenantID string) (azcore.TokenCredential, error) {
 }
 
 // testCredential verifies that a credential can obtain a token
-func testCredential(ctx context.Context, cred azcore.TokenCredential) error {
+func testCredential(ctx context.Context, env cloudenv.Environment, cred azcore.TokenCredential) error {
 	// Try to get a token for Microsoft Graph
 	_, err := cred.GetToken(ctx, policy.TokenRequestOptions{
-		Scopes: []string{"https://graph.microsoft.com/.default"},
+		Scopes: []string{env.GraphScope},
 	})
 	return err
 }
 
 // validateAzureConnection ensures we can connect to Azure and get basic info
-func validateAzureConnection(ctx context.Context, cred azcore.TokenCredential, verbose bool) error {
+func validateAzureConnection(ctx context.Context, env cloudenv.Environment, cred azcore.TokenCredential, verbose bool) error {
 	if verbose {
 		fmt.Println("🔍 Validating Azure connection...")
 	}
 
 	// Try to get a token to verify the connection works
 	token, err := cred.GetToken(ctx, policy.TokenRequestOptions{
-		Scopes: []string{"https://graph.microsoft.com/.default"},
+		Scopes: []string{env.GraphScope},
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to obtain access token from Azure")

--- a/cmd/azure-setup/auth_test.go
+++ b/cmd/azure-setup/auth_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
 )
 
 // TestAuthenticationMethods tests the authentication method priority
@@ -29,24 +31,28 @@ func TestAuthenticationMethods(t *testing.T) {
 // TestTryEnvironmentCredential tests environment credential creation
 func TestTryEnvironmentCredential(t *testing.T) {
 	tests := []struct {
-		name     string
-		tenantID string
+		name  string
+		cloud string
 	}{
 		{
-			name:     "with_tenant_id",
-			tenantID: "test-tenant-123",
+			name:  "commercial",
+			cloud: cloudenv.Commercial,
 		},
 		{
-			name:     "without_tenant_id",
-			tenantID: "",
+			name:  "gcchigh",
+			cloud: cloudenv.GCCHigh,
+		},
+		{
+			name:  "dod",
+			cloud: cloudenv.DoD,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// tryEnvironmentCredential will fail without env vars set
-			// but we can verify it doesn't panic
-			_, err := tryEnvironmentCredential(tt.tenantID)
+			// but we can verify it doesn't panic for any cloud.
+			_, err := tryEnvironmentCredential(cloudenv.EnvironmentFor(tt.cloud))
 			// Expected to fail without env vars
 			assert.Error(t, err)
 		})
@@ -86,7 +92,7 @@ func TestTryAzureCLICredential(t *testing.T) {
 func TestTryInteractiveBrowserCredential(t *testing.T) {
 	t.Run("creates_credential_object", func(t *testing.T) {
 		tenantID := "test-tenant-123"
-		cred, err := tryInteractiveBrowserCredential(tenantID)
+		cred, err := tryInteractiveBrowserCredential(cloudenv.EnvironmentFor(cloudenv.Commercial), tenantID)
 
 		// Should create credential object even without authentication
 		assert.NoError(t, err)
@@ -94,9 +100,17 @@ func TestTryInteractiveBrowserCredential(t *testing.T) {
 	})
 
 	t.Run("without_tenant_id", func(t *testing.T) {
-		cred, err := tryInteractiveBrowserCredential("")
+		cred, err := tryInteractiveBrowserCredential(cloudenv.EnvironmentFor(cloudenv.Commercial), "")
 
 		// Should create credential object even without tenant ID
+		assert.NoError(t, err)
+		assert.NotNil(t, cred)
+	})
+
+	t.Run("gcchigh_cloud", func(t *testing.T) {
+		cred, err := tryInteractiveBrowserCredential(cloudenv.EnvironmentFor(cloudenv.GCCHigh), "test-tenant-123")
+
+		// Should create a credential object for the gov cloud too.
 		assert.NoError(t, err)
 		assert.NotNil(t, cred)
 	})
@@ -106,7 +120,7 @@ func TestTryInteractiveBrowserCredential(t *testing.T) {
 func TestTryDeviceCodeCredential(t *testing.T) {
 	t.Run("creates_credential_object", func(t *testing.T) {
 		tenantID := "test-tenant-123"
-		cred, err := tryDeviceCodeCredential(tenantID)
+		cred, err := tryDeviceCodeCredential(cloudenv.EnvironmentFor(cloudenv.Commercial), tenantID)
 
 		// Should create credential object even without authentication
 		assert.NoError(t, err)
@@ -114,7 +128,7 @@ func TestTryDeviceCodeCredential(t *testing.T) {
 	})
 
 	t.Run("without_tenant_id", func(t *testing.T) {
-		cred, err := tryDeviceCodeCredential("")
+		cred, err := tryDeviceCodeCredential(cloudenv.EnvironmentFor(cloudenv.Commercial), "")
 
 		// Should create credential object even without tenant ID
 		assert.NoError(t, err)

--- a/cmd/azure-setup/main.go
+++ b/cmd/azure-setup/main.go
@@ -104,14 +104,14 @@ func init() {
 	createCmd.Flags().BoolVarP(&flagVerbose, "verbose", "v", false, "Enable verbose output")
 	createCmd.Flags().StringVarP(&flagOutputFormat, "output", "o", "human", "Output format (human, json, env, mattermost)")
 	createCmd.Flags().BoolVarP(&flagYes, "yes", "y", false, "Skip confirmation prompt and proceed with changes")
-	createCmd.Flags().StringVar(&flagCloud, "cloud", "commercial", "Microsoft national cloud (commercial, gcchigh, dod)")
+	createCmd.Flags().StringVar(&flagCloud, "cloud", cloudenv.Commercial, "Microsoft national cloud (commercial, gcchigh, dod)")
 
 	_ = createCmd.MarkFlagRequired("site-url")
 
 	// Validate command flags
 	validateCmd.Flags().StringVar(&flagTenantID, "tenant-id", "", "Azure AD Tenant ID (optional)")
 	validateCmd.Flags().BoolVarP(&flagVerbose, "verbose", "v", false, "Enable verbose output")
-	validateCmd.Flags().StringVar(&flagCloud, "cloud", "commercial", "Microsoft national cloud (commercial, gcchigh, dod)")
+	validateCmd.Flags().StringVar(&flagCloud, "cloud", cloudenv.Commercial, "Microsoft national cloud (commercial, gcchigh, dod)")
 
 	rootCmd.AddCommand(createCmd)
 	rootCmd.AddCommand(validateCmd)
@@ -146,7 +146,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "invalid input")
 	}
 
-	env := cloudenv.EnvironmentFor(config.Cloud)
+	env := config.cloudEnvironment()
 
 	// Authenticate to Azure
 	cred, err := authenticateToAzure(ctx, env, config.TenantID, config.Verbose)
@@ -160,8 +160,9 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Azure connection validation failed")
 	}
 
-	// Create Graph client
-	authProvider, err := authentication.NewAzureIdentityAuthenticationProvider(cred)
+	// Create Graph client. Use the selected cloud's Graph scope so the token
+	// audience matches the cloud's Graph endpoint (for example graph.microsoft.us).
+	authProvider, err := authentication.NewAzureIdentityAuthenticationProviderWithScopes(cred, []string{env.GraphScope})
 	if err != nil {
 		return errors.Wrap(err, "failed to create auth provider")
 	}
@@ -213,7 +214,10 @@ func runValidate(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("🔍 Validating Azure credentials and permissions...")
 
-	env := cloudenv.EnvironmentFor(flagCloud)
+	env, err := resolveCloud(flagCloud)
+	if err != nil {
+		return errors.Wrap(err, "invalid input")
+	}
 
 	// Authenticate to Azure
 	cred, err := authenticateToAzure(ctx, env, flagTenantID, flagVerbose)
@@ -226,8 +230,9 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Azure connection validation failed")
 	}
 
-	// Create Graph client
-	authProvider, err := authentication.NewAzureIdentityAuthenticationProvider(cred)
+	// Create Graph client. Use the selected cloud's Graph scope so the token
+	// audience matches the cloud's Graph endpoint (for example graph.microsoft.us).
+	authProvider, err := authentication.NewAzureIdentityAuthenticationProviderWithScopes(cred, []string{env.GraphScope})
 	if err != nil {
 		return errors.Wrap(err, "failed to create auth provider")
 	}
@@ -311,7 +316,7 @@ func executeSetup(ctx context.Context, client *msgraphsdk.GraphServiceClient, co
 		ApplicationID:       *app.GetId(),
 		ApplicationName:     *app.GetDisplayName(),
 		ApplicationIDURI:    appIDURI,
-		PortalHost:          cloudenv.EnvironmentFor(config.Cloud).PortalHost,
+		PortalHost:          config.cloudEnvironment().PortalHost,
 		Created:             created,
 		DryRun:              config.DryRun,
 	}

--- a/cmd/azure-setup/main.go
+++ b/cmd/azure-setup/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
 )
 
 var version = "dev"
@@ -87,6 +89,7 @@ var (
 	flagVerbose          bool
 	flagOutputFormat     string
 	flagYes              bool
+	flagCloud            string
 )
 
 func init() {
@@ -101,12 +104,14 @@ func init() {
 	createCmd.Flags().BoolVarP(&flagVerbose, "verbose", "v", false, "Enable verbose output")
 	createCmd.Flags().StringVarP(&flagOutputFormat, "output", "o", "human", "Output format (human, json, env, mattermost)")
 	createCmd.Flags().BoolVarP(&flagYes, "yes", "y", false, "Skip confirmation prompt and proceed with changes")
+	createCmd.Flags().StringVar(&flagCloud, "cloud", "commercial", "Microsoft national cloud (commercial, gcchigh, dod)")
 
 	_ = createCmd.MarkFlagRequired("site-url")
 
 	// Validate command flags
 	validateCmd.Flags().StringVar(&flagTenantID, "tenant-id", "", "Azure AD Tenant ID (optional)")
 	validateCmd.Flags().BoolVarP(&flagVerbose, "verbose", "v", false, "Enable verbose output")
+	validateCmd.Flags().StringVar(&flagCloud, "cloud", "commercial", "Microsoft national cloud (commercial, gcchigh, dod)")
 
 	rootCmd.AddCommand(createCmd)
 	rootCmd.AddCommand(validateCmd)
@@ -131,6 +136,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		Verbose:           flagVerbose,
 		OutputFormat:      flagOutputFormat,
 		SkipConfirmation:  flagYes,
+		Cloud:             flagCloud,
 		ctx:               ctx,
 		rollback:          []func() error{},
 	}
@@ -140,15 +146,17 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "invalid input")
 	}
 
+	env := cloudenv.EnvironmentFor(config.Cloud)
+
 	// Authenticate to Azure
-	cred, err := authenticateToAzure(ctx, config.TenantID, config.Verbose)
+	cred, err := authenticateToAzure(ctx, env, config.TenantID, config.Verbose)
 	if err != nil {
 		return errors.Wrap(err, "authentication failed")
 	}
 	config.credential = cred
 
 	// Validate Azure connection
-	if err = validateAzureConnection(ctx, cred, config.Verbose); err != nil {
+	if err = validateAzureConnection(ctx, env, cred, config.Verbose); err != nil {
 		return errors.Wrap(err, "Azure connection validation failed")
 	}
 
@@ -162,6 +170,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create Graph adapter")
 	}
+	adapter.SetBaseUrl(env.GraphBaseURL)
 
 	client := msgraphsdk.NewGraphServiceClient(adapter)
 
@@ -204,14 +213,16 @@ func runValidate(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("🔍 Validating Azure credentials and permissions...")
 
+	env := cloudenv.EnvironmentFor(flagCloud)
+
 	// Authenticate to Azure
-	cred, err := authenticateToAzure(ctx, flagTenantID, flagVerbose)
+	cred, err := authenticateToAzure(ctx, env, flagTenantID, flagVerbose)
 	if err != nil {
 		return errors.Wrap(err, "authentication failed")
 	}
 
 	// Validate Azure connection
-	if err = validateAzureConnection(ctx, cred, flagVerbose); err != nil {
+	if err = validateAzureConnection(ctx, env, cred, flagVerbose); err != nil {
 		return errors.Wrap(err, "Azure connection validation failed")
 	}
 
@@ -225,6 +236,7 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create Graph adapter")
 	}
+	adapter.SetBaseUrl(env.GraphBaseURL)
 
 	client := msgraphsdk.NewGraphServiceClient(adapter)
 
@@ -299,6 +311,7 @@ func executeSetup(ctx context.Context, client *msgraphsdk.GraphServiceClient, co
 		ApplicationID:       *app.GetId(),
 		ApplicationName:     *app.GetDisplayName(),
 		ApplicationIDURI:    appIDURI,
+		PortalHost:          cloudenv.EnvironmentFor(config.Cloud).PortalHost,
 		Created:             created,
 		DryRun:              config.DryRun,
 	}

--- a/cmd/azure-setup/output.go
+++ b/cmd/azure-setup/output.go
@@ -75,8 +75,12 @@ func outputHuman(result *SetupResult) error {
 
 	fmt.Println("\n📝 NEXT STEPS")
 	fmt.Println(strings.Repeat("-", 70))
+	portalHost := result.PortalHost
+	if portalHost == "" {
+		portalHost = "portal.azure.com"
+	}
 	fmt.Println("1. Grant admin consent for API permissions:")
-	fmt.Printf("   https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/CallAnAPI/appId/%s\n", result.ApplicationClientID)
+	fmt.Printf("   https://%s/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/CallAnAPI/appId/%s\n", portalHost, result.ApplicationClientID)
 	fmt.Println("\n2. Configure the Mattermost plugin with these values:")
 	fmt.Println("   - System Console > Plugins > MS Teams DevSecOps")
 	fmt.Println("   - Enter the Tenant ID, Client ID, and Client Secret above")

--- a/cmd/azure-setup/permissions.go
+++ b/cmd/azure-setup/permissions.go
@@ -12,6 +12,8 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/serviceprincipals"
 	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
 )
 
 // configureAPIPermissions adds the required API permissions to the application
@@ -170,7 +172,7 @@ func ensureServicePrincipalExists(ctx context.Context, client *msgraphsdk.GraphS
 		// Validate UUID before constructing URL
 		if _, err := uuid.Parse(appID); err == nil {
 			fmt.Printf("✅ Admin consent must be granted manually\n")
-			fmt.Printf("   Visit: https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/CallAnAPI/appId/%s\n", appID)
+			fmt.Printf("   Visit: https://%s/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/CallAnAPI/appId/%s\n", cloudenv.EnvironmentFor(config.Cloud).PortalHost, appID)
 		}
 	}
 

--- a/cmd/azure-setup/permissions.go
+++ b/cmd/azure-setup/permissions.go
@@ -12,8 +12,6 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/serviceprincipals"
 	"github.com/pkg/errors"
-
-	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
 )
 
 // configureAPIPermissions adds the required API permissions to the application
@@ -172,7 +170,7 @@ func ensureServicePrincipalExists(ctx context.Context, client *msgraphsdk.GraphS
 		// Validate UUID before constructing URL
 		if _, err := uuid.Parse(appID); err == nil {
 			fmt.Printf("✅ Admin consent must be granted manually\n")
-			fmt.Printf("   Visit: https://%s/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/CallAnAPI/appId/%s\n", cloudenv.EnvironmentFor(config.Cloud).PortalHost, appID)
+			fmt.Printf("   Visit: https://%s/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/CallAnAPI/appId/%s\n", config.cloudEnvironment().PortalHost, appID)
 		}
 	}
 

--- a/cmd/azure-setup/types.go
+++ b/cmd/azure-setup/types.go
@@ -7,6 +7,8 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
 )
 
 // Microsoft Graph API Permission IDs and Types
@@ -84,6 +86,13 @@ type SetupConfig struct {
 	ctx        context.Context
 	credential azcore.TokenCredential
 	rollback   []func() error
+}
+
+// cloudEnvironment resolves the Microsoft national cloud endpoints for the
+// configured Cloud value. It is the single resolution point used across the
+// setup flow so every step targets the same, consistent cloud.
+func (c *SetupConfig) cloudEnvironment() cloudenv.Environment {
+	return cloudenv.EnvironmentFor(c.Cloud)
 }
 
 // SetupResult contains the results of the Azure setup operation

--- a/cmd/azure-setup/types.go
+++ b/cmd/azure-setup/types.go
@@ -78,6 +78,7 @@ type SetupConfig struct {
 	Verbose          bool
 	OutputFormat     string // "human", "json", "env"
 	SkipConfirmation bool   // Skip pre-flight confirmation prompt
+	Cloud            string // Microsoft national cloud: "commercial" (default), "gcchigh", or "dod"
 
 	// Internal state
 	ctx        context.Context
@@ -100,6 +101,10 @@ type SetupResult struct {
 	ApplicationID    string
 	ApplicationName  string
 	ApplicationIDURI string
+
+	// PortalHost is the Azure portal host for the selected national cloud,
+	// used to render the admin-consent link (e.g. portal.azure.com).
+	PortalHost string
 
 	// Operation Details
 	Created bool // true if created new, false if updated existing

--- a/cmd/azure-setup/validate.go
+++ b/cmd/azure-setup/validate.go
@@ -56,15 +56,30 @@ func validateInputs(config *SetupConfig) error {
 		return errors.New("secret expiration cannot exceed 24 months")
 	}
 
-	// Validate national cloud
-	if config.Cloud == "" {
-		config.Cloud = cloudenv.Commercial
+	// Validate and normalize the national cloud.
+	env, err := resolveCloud(config.Cloud)
+	if err != nil {
+		return err
 	}
-	if !slices.Contains(cloudenv.Names(), config.Cloud) {
-		return errors.Errorf("invalid --cloud value %q: must be one of %v", config.Cloud, cloudenv.Names())
-	}
+	config.Cloud = env.Name
 
 	return nil
+}
+
+// resolveCloud normalizes and validates a national cloud name supplied via the
+// --cloud flag and returns the resolved environment. Normalization (trim and
+// lowercase) matches cloudenv.EnvironmentFor so validation and resolution agree,
+// an empty value defaults to the commercial cloud, and any value not in
+// cloudenv.Names() is rejected so typos fail fast instead of silently defaulting.
+func resolveCloud(name string) (cloudenv.Environment, error) {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "" {
+		normalized = cloudenv.Commercial
+	}
+	if !slices.Contains(cloudenv.Names(), normalized) {
+		return cloudenv.Environment{}, errors.Errorf("invalid --cloud value %q: must be one of %v", name, cloudenv.Names())
+	}
+	return cloudenv.EnvironmentFor(normalized), nil
 }
 
 // validatePermissions checks if the authenticated user has the necessary permissions

--- a/cmd/azure-setup/validate.go
+++ b/cmd/azure-setup/validate.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/applications"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
 )
 
 // validateInputs validates all user inputs before proceeding
@@ -51,6 +54,14 @@ func validateInputs(config *SetupConfig) error {
 
 	if config.SecretExpiration > 24 {
 		return errors.New("secret expiration cannot exceed 24 months")
+	}
+
+	// Validate national cloud
+	if config.Cloud == "" {
+		config.Cloud = cloudenv.Commercial
+	}
+	if !slices.Contains(cloudenv.Names(), config.Cloud) {
+		return errors.Errorf("invalid --cloud value %q: must be one of %v", config.Cloud, cloudenv.Names())
 	}
 
 	return nil

--- a/cmd/azure-setup/validate_test.go
+++ b/cmd/azure-setup/validate_test.go
@@ -8,7 +8,41 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
 )
+
+func TestResolveCloud(t *testing.T) {
+	t.Run("valid values resolve", func(t *testing.T) {
+		cases := map[string]string{
+			"commercial": cloudenv.Commercial,
+			"gcchigh":    cloudenv.GCCHigh,
+			"dod":        cloudenv.DoD,
+		}
+		for input, want := range cases {
+			env, err := resolveCloud(input)
+			require.NoError(t, err)
+			assert.Equal(t, want, env.Name)
+		}
+	})
+
+	t.Run("empty defaults to commercial", func(t *testing.T) {
+		env, err := resolveCloud("")
+		require.NoError(t, err)
+		assert.Equal(t, cloudenv.Commercial, env.Name)
+	})
+
+	t.Run("normalizes case and whitespace like EnvironmentFor", func(t *testing.T) {
+		env, err := resolveCloud("  GCCHigh  ")
+		require.NoError(t, err)
+		assert.Equal(t, cloudenv.GCCHigh, env.Name)
+	})
+
+	t.Run("rejects unknown values instead of defaulting", func(t *testing.T) {
+		_, err := resolveCloud("sovereign-cloud")
+		require.Error(t, err)
+	})
+}
 
 func TestValidateInputs(t *testing.T) {
 	tests := []struct {

--- a/plugin.json
+++ b/plugin.json
@@ -54,6 +54,27 @@
                         "type": "bool",
                         "help_text": "Disables notifications from Mattermost as activities in Microsoft Teams.",
                         "default": false
+                    },
+                    {
+                        "key": "national_cloud",
+                        "display_name": "Microsoft National Cloud",
+                        "type": "dropdown",
+                        "help_text": "The Microsoft national cloud your tenant belongs to. Use Commercial for standard Microsoft 365 and GCC. Changing this requires re-running azure-setup with the matching --cloud value and re-uploading the app to the correct cloud's tenant catalog.",
+                        "default": "commercial",
+                        "options": [
+                            {
+                                "display_name": "Commercial (also GCC)",
+                                "value": "commercial"
+                            },
+                            {
+                                "display_name": "GCC High (US Gov L4)",
+                                "value": "gcchigh"
+                            },
+                            {
+                                "display_name": "DoD (US Gov L5)",
+                                "value": "dod"
+                            }
+                        ]
                     }
                 ]
             },

--- a/server/api_csp.go
+++ b/server/api_csp.go
@@ -9,8 +9,11 @@ import (
 )
 
 const (
-	DefaultCSPConnectSrc = "https://*.microsoft.com https://*.teams.microsoft.com https://*.cdn.office.net"
-	DefaultCSPScriptSrc  = "https://res.cdn.office.net https://cdn.jsdelivr.net"
+	// DefaultCSPScriptSrc is the script-src for the iframe CSP. It is not
+	// per-cloud: the Microsoft Teams JS SDK is served from the same
+	// res.cdn.office.net CDN across all national clouds. Per-cloud connect-src
+	// values come from cloudenv.Environment.CSPConnectSrc.
+	DefaultCSPScriptSrc = "https://res.cdn.office.net https://cdn.jsdelivr.net"
 
 	// maxCSPReportFieldLen limits logged CSP report string fields to prevent log injection and size abuse.
 	maxCSPReportFieldLen = 500

--- a/server/api_sso.go
+++ b/server/api_sso.go
@@ -57,7 +57,7 @@ func (a *API) handleSSOComplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	iFrameCtx.CSPConnectSrc = DefaultCSPConnectSrc
+	iFrameCtx.CSPConnectSrc = a.p.getConfiguration().CloudEnvironment().CSPConnectSrc
 	iFrameCtx.CSPScriptSrc = DefaultCSPScriptSrc
 
 	a.returnCSPHeaders(w, iFrameCtx)

--- a/server/cloudenv/cloudenv.go
+++ b/server/cloudenv/cloudenv.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Package cloudenv describes the Microsoft national cloud environments this plugin
+// supports (commercial, US Government GCC High, and US Government DoD) and maps each
+// to the endpoints, scopes, and domains that differ between clouds.
+//
+// GCC (moderate) is intentionally not a separate environment: it rides on the
+// commercial endpoints and is therefore covered by Commercial. China (21Vianet) and
+// air-gapped classified clouds are out of scope.
+//
+// Note: cloud.AzureGovernment selects the login authority (login.microsoftonline.us)
+// for both GCC High and DoD, but does not distinguish their Graph hosts
+// (graph.microsoft.us vs dod-graph.microsoft.us), so GraphBaseURL is set explicitly.
+package cloudenv
+
+import (
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+)
+
+// Recognized cloud names. These are the accepted values for the plugin's
+// national_cloud setting and the azure-setup --cloud flag.
+const (
+	Commercial = "commercial"
+	GCCHigh    = "gcchigh"
+	DoD        = "dod"
+)
+
+// Environment holds all cloud-specific endpoints and domains for a Microsoft
+// national cloud.
+type Environment struct {
+	// Name is the recognized cloud name (see the constants above).
+	Name string
+
+	// LoginAuthorityHost is the Microsoft Entra host used to build OAuth
+	// authorize/token URLs (e.g. login.microsoftonline.com).
+	LoginAuthorityHost string
+
+	// GraphHost is the Microsoft Graph service host (e.g. graph.microsoft.com).
+	GraphHost string
+
+	// GraphBaseURL is the Microsoft Graph service root, including the version
+	// segment (e.g. https://graph.microsoft.com/v1.0). It is set explicitly on
+	// the Graph SDK adapter because DoD uses a different Graph host than GCC High.
+	GraphBaseURL string
+
+	// GraphScope is the OAuth .default scope for Microsoft Graph
+	// (e.g. https://graph.microsoft.com/.default).
+	GraphScope string
+
+	// JWKSURL serves the signing keys used to validate Teams SSO tokens.
+	JWKSURL string
+
+	// AzureCloud is the azcore cloud configuration passed to the Azure SDK
+	// credentials so tokens are acquired from the correct authority.
+	AzureCloud cloud.Configuration
+
+	// TeamsDomain is the Microsoft Teams client host, used for activity-feed
+	// deep links and for embedding (e.g. teams.microsoft.com).
+	TeamsDomain string
+
+	// PortalHost is the Azure portal host, used for admin-consent links
+	// (e.g. portal.azure.com).
+	PortalHost string
+
+	// FrameAncestors lists the domains added to the Mattermost server's
+	// frame-ancestors so the plugin iframe can be embedded in this cloud's
+	// Microsoft 365 clients.
+	//
+	// The Teams client domain is authoritative. The Outlook/M365 gov domains
+	// below are best-effort and may need refinement once verified against a
+	// gov tenant (tracked as a verification item in the implementation plan).
+	FrameAncestors []string
+
+	// CSPConnectSrc is the connect-src value for the iframe Content Security
+	// Policy. The script-src is intentionally not per-cloud: the Teams JS SDK
+	// is served from the same res.cdn.office.net CDN across all clouds.
+	CSPConnectSrc string
+}
+
+func commercial() Environment {
+	return Environment{
+		Name:               Commercial,
+		LoginAuthorityHost: "login.microsoftonline.com",
+		GraphHost:          "graph.microsoft.com",
+		GraphBaseURL:       "https://graph.microsoft.com/v1.0",
+		GraphScope:         "https://graph.microsoft.com/.default",
+		JWKSURL:            "https://login.microsoftonline.com/common/discovery/v2.0/keys",
+		AzureCloud:         cloud.AzurePublic,
+		TeamsDomain:        "teams.microsoft.com",
+		PortalHost:         "portal.azure.com",
+		FrameAncestors: []string{
+			"*.cloud.microsoft",
+			"teams.microsoft.com",
+			"*.teams.microsoft.com",
+			"*.microsoft365.com",
+			"*.office.com",
+			"outlook.office.com",
+			"outlook.office365.com",
+			"outlook-sdf.office.com",
+			"outlook-sdf.office365.com",
+		},
+		CSPConnectSrc: "https://*.microsoft.com https://*.teams.microsoft.com https://*.cdn.office.net",
+	}
+}
+
+func gccHigh() Environment {
+	return Environment{
+		Name:               GCCHigh,
+		LoginAuthorityHost: "login.microsoftonline.us",
+		GraphHost:          "graph.microsoft.us",
+		GraphBaseURL:       "https://graph.microsoft.us/v1.0",
+		GraphScope:         "https://graph.microsoft.us/.default",
+		JWKSURL:            "https://login.microsoftonline.us/common/discovery/v2.0/keys",
+		AzureCloud:         cloud.AzureGovernment,
+		TeamsDomain:        "gov.teams.microsoft.us",
+		PortalHost:         "portal.azure.us",
+		FrameAncestors: []string{
+			"*.cloud.microsoft",
+			"gov.teams.microsoft.us",
+			"*.gov.teams.microsoft.us",
+			"*.office365.us",
+			"outlook.office365.us",
+		},
+		CSPConnectSrc: "https://*.microsoft.us https://*.teams.microsoft.us https://*.cdn.office.net",
+	}
+}
+
+func dod() Environment {
+	return Environment{
+		Name:               DoD,
+		LoginAuthorityHost: "login.microsoftonline.us",
+		GraphHost:          "dod-graph.microsoft.us",
+		GraphBaseURL:       "https://dod-graph.microsoft.us/v1.0",
+		GraphScope:         "https://dod-graph.microsoft.us/.default",
+		JWKSURL:            "https://login.microsoftonline.us/common/discovery/v2.0/keys",
+		AzureCloud:         cloud.AzureGovernment,
+		TeamsDomain:        "dod.teams.microsoft.us",
+		PortalHost:         "portal.azure.us",
+		FrameAncestors: []string{
+			"*.cloud.microsoft",
+			"dod.teams.microsoft.us",
+			"*.dod.teams.microsoft.us",
+			"*.dod.online.office365.us",
+		},
+		CSPConnectSrc: "https://*.microsoft.us https://*.teams.microsoft.us https://*.cdn.office.net",
+	}
+}
+
+// EnvironmentFor returns the cloud environment for the given name, defaulting to
+// the commercial cloud for empty or unrecognized names. Matching is
+// case-insensitive and ignores surrounding whitespace.
+func EnvironmentFor(name string) Environment {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case GCCHigh:
+		return gccHigh()
+	case DoD:
+		return dod()
+	default:
+		return commercial()
+	}
+}
+
+// Names returns the recognized cloud names, commercial first.
+func Names() []string {
+	return []string{Commercial, GCCHigh, DoD}
+}

--- a/server/cloudenv/cloudenv_test.go
+++ b/server/cloudenv/cloudenv_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package cloudenv
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvironmentForResolution(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantName string
+	}{
+		{"empty defaults to commercial", "", Commercial},
+		{"unknown defaults to commercial", "azure-secret", Commercial},
+		{"commercial", "commercial", Commercial},
+		{"gcchigh", "gcchigh", GCCHigh},
+		{"dod", "dod", DoD},
+		{"case insensitive", "GCCHigh", GCCHigh},
+		{"trims whitespace", "  dod  ", DoD},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantName, EnvironmentFor(tt.input).Name)
+		})
+	}
+}
+
+// TestCommercialByteIdentical guards against regressions: the commercial
+// environment must produce exactly the strings the plugin hardcoded before
+// national cloud support was added.
+func TestCommercialByteIdentical(t *testing.T) {
+	env := EnvironmentFor(Commercial)
+
+	assert.Equal(t, "login.microsoftonline.com", env.LoginAuthorityHost)
+	assert.Equal(t, "graph.microsoft.com", env.GraphHost)
+	assert.Equal(t, "https://graph.microsoft.com/v1.0", env.GraphBaseURL)
+	assert.Equal(t, "https://graph.microsoft.com/.default", env.GraphScope)
+	assert.Equal(t, "https://login.microsoftonline.com/common/discovery/v2.0/keys", env.JWKSURL)
+	assert.Equal(t, "teams.microsoft.com", env.TeamsDomain)
+	assert.Equal(t, "portal.azure.com", env.PortalHost)
+
+	// The previous hardcoded frame-ancestors string (server/plugin.go).
+	assert.Equal(t,
+		"*.cloud.microsoft teams.microsoft.com *.teams.microsoft.com *.microsoft365.com *.office.com outlook.office.com outlook.office365.com outlook-sdf.office.com outlook-sdf.office365.com",
+		strings.Join(env.FrameAncestors, " "),
+	)
+
+	// The previous hardcoded DefaultCSPConnectSrc (server/api_csp.go).
+	assert.Equal(t, "https://*.microsoft.com https://*.teams.microsoft.com https://*.cdn.office.net", env.CSPConnectSrc)
+
+	// Commercial must use the Azure public cloud authority.
+	assert.Equal(t, cloud.AzurePublic.ActiveDirectoryAuthorityHost, env.AzureCloud.ActiveDirectoryAuthorityHost)
+}
+
+func TestGCCHighEndpoints(t *testing.T) {
+	env := EnvironmentFor(GCCHigh)
+
+	assert.Equal(t, "login.microsoftonline.us", env.LoginAuthorityHost)
+	assert.Equal(t, "graph.microsoft.us", env.GraphHost)
+	assert.Equal(t, "https://graph.microsoft.us/v1.0", env.GraphBaseURL)
+	assert.Equal(t, "https://graph.microsoft.us/.default", env.GraphScope)
+	assert.Equal(t, "https://login.microsoftonline.us/common/discovery/v2.0/keys", env.JWKSURL)
+	assert.Equal(t, "gov.teams.microsoft.us", env.TeamsDomain)
+	assert.Equal(t, "portal.azure.us", env.PortalHost)
+	assert.Equal(t, cloud.AzureGovernment.ActiveDirectoryAuthorityHost, env.AzureCloud.ActiveDirectoryAuthorityHost)
+	assert.Contains(t, env.FrameAncestors, "gov.teams.microsoft.us")
+	assert.Contains(t, env.CSPConnectSrc, "https://*.teams.microsoft.us")
+}
+
+func TestDoDEndpoints(t *testing.T) {
+	env := EnvironmentFor(DoD)
+
+	// DoD shares the login authority with GCC High but uses a distinct Graph host.
+	assert.Equal(t, "login.microsoftonline.us", env.LoginAuthorityHost)
+	assert.Equal(t, "dod-graph.microsoft.us", env.GraphHost)
+	assert.Equal(t, "https://dod-graph.microsoft.us/v1.0", env.GraphBaseURL)
+	assert.Equal(t, "https://dod-graph.microsoft.us/.default", env.GraphScope)
+	assert.Equal(t, "https://login.microsoftonline.us/common/discovery/v2.0/keys", env.JWKSURL)
+	assert.Equal(t, "dod.teams.microsoft.us", env.TeamsDomain)
+	assert.Equal(t, "portal.azure.us", env.PortalHost)
+	assert.Equal(t, cloud.AzureGovernment.ActiveDirectoryAuthorityHost, env.AzureCloud.ActiveDirectoryAuthorityHost)
+	assert.Contains(t, env.FrameAncestors, "dod.teams.microsoft.us")
+}
+
+func TestNames(t *testing.T) {
+	assert.Equal(t, []string{Commercial, GCCHigh, DoD}, Names())
+}

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -246,8 +246,23 @@ func (p *Plugin) OnConfigurationChange() error {
 		}
 	*/
 
+	// Detect a national cloud change so we can refresh frame ancestors below.
+	// (The initial value is applied by OnActivate.)
+	cloudChanged := p.getConfiguration().NationalCloud != newConfig.NationalCloud
+
 	// Apply the new configuration
 	p.setConfiguration(newConfig)
+
+	// If the national cloud changed after activation, refresh the server's
+	// frame ancestors so the new cloud's embedding domains are allowed. Guarded
+	// by p.client (set in OnActivate) since OnConfigurationChange can run before
+	// activation. updateFrameAncestors is union-only and idempotent, so the
+	// SaveConfig it may issue converges without looping.
+	if p.client != nil && cloudChanged {
+		if err := p.updateFrameAncestors(); err != nil {
+			p.API.LogWarn("Failed to update frame ancestors", "error", err.Error())
+		}
+	}
 
 	// Only restart the application if the OnActivate is already executed
 	if p.pluginStore != nil {

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
 )
 
 // configuration captures the plugin's external configuration as exposed in the Mattermost server
@@ -28,6 +30,11 @@ type configuration struct {
 	// Plugin Settings
 	DisableUserActivityNotifications bool `json:"disable_user_activity_notifications"`
 	DisableCheckCredentials          bool `json:"internal_disable_check_credentials"`
+
+	// NationalCloud selects the Microsoft national cloud to target: "commercial"
+	// (default, also covers GCC moderate), "gcchigh", or "dod". An empty or
+	// unrecognized value resolves to the commercial cloud.
+	NationalCloud string `json:"national_cloud"`
 
 	// Manifest Settings
 	AppVersion string `json:"app_version"`
@@ -120,6 +127,12 @@ func (p *Plugin) validateConfiguration(configuration *configuration) error {
 		return errors.New("app name should not be empty")
 	}
 	return nil
+}
+
+// CloudEnvironment resolves the Microsoft national cloud endpoints for the
+// configured NationalCloud value, defaulting to the commercial cloud.
+func (c *configuration) CloudEnvironment() cloudenv.Environment {
+	return cloudenv.EnvironmentFor(c.NationalCloud)
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -135,6 +135,13 @@ func (c *configuration) CloudEnvironment() cloudenv.Environment {
 	return cloudenv.EnvironmentFor(c.NationalCloud)
 }
 
+// isM365Configured reports whether the credentials required to connect to the
+// Microsoft Graph API are all present. Until they are, connecting is skipped so
+// an unconfigured install stays quiet.
+func (c *configuration) isM365Configured() bool {
+	return c.M365TenantID != "" && c.M365ClientID != "" && c.M365ClientSecret != ""
+}
+
 // Clone shallow copies the configuration. Your implementation may require a deep copy if
 // your configuration has reference types.
 func (c *configuration) Clone() *configuration {

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsM365Configured(t *testing.T) {
+	tests := []struct {
+		name   string
+		config configuration
+		want   bool
+	}{
+		{"all set", configuration{M365TenantID: "t", M365ClientID: "c", M365ClientSecret: "s"}, true},
+		{"all empty", configuration{}, false},
+		{"missing tenant", configuration{M365ClientID: "c", M365ClientSecret: "s"}, false},
+		{"missing client id", configuration{M365TenantID: "t", M365ClientSecret: "s"}, false},
+		{"missing secret", configuration{M365TenantID: "t", M365ClientID: "c"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.config.isM365Configured())
+		})
+	}
+}

--- a/server/helper_test.go
+++ b/server/helper_test.go
@@ -48,7 +48,7 @@ func setupTestHelper(t *testing.T) *testHelper {
 	// Set up JWK to validate JWTs from Microsoft Teams.
 	p.cancelKeyFuncLock.Lock()
 	if p.cancelKeyFunc == nil {
-		p.tabAppJWTKeyFunc, p.cancelKeyFunc = setupJWKSet()
+		p.tabAppJWTKeyFunc, p.cancelKeyFunc = setupJWKSet(p.getConfiguration().CloudEnvironment().JWKSURL)
 	}
 	p.cancelKeyFuncLock.Unlock()
 

--- a/server/helper_test.go
+++ b/server/helper_test.go
@@ -46,11 +46,7 @@ func setupTestHelper(t *testing.T) *testHelper {
 	}
 
 	// Set up JWK to validate JWTs from Microsoft Teams.
-	p.cancelKeyFuncLock.Lock()
-	if p.cancelKeyFunc == nil {
-		p.tabAppJWTKeyFunc, p.cancelKeyFunc = setupJWKSet(p.getConfiguration().CloudEnvironment().JWKSURL)
-	}
-	p.cancelKeyFuncLock.Unlock()
+	p.ensureJWKS()
 
 	// ctx, and specifically cancel, gives us control over the plugin lifecycle
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/iframe.go
+++ b/server/iframe.go
@@ -72,7 +72,7 @@ func (a *API) iFrame(w http.ResponseWriter, r *http.Request) {
 	}
 
 	iFrameCtx.CSPScriptSrc = "https://res.cdn.office.net"
-	iFrameCtx.CSPConnectSrc = DefaultCSPConnectSrc
+	iFrameCtx.CSPConnectSrc = a.p.getConfiguration().CloudEnvironment().CSPConnectSrc
 	iFrameCtx.CSPFrameSrc = "self"
 
 	a.returnCSPHeaders(w, iFrameCtx)
@@ -135,7 +135,7 @@ func (a *API) iframeNotificationPreview(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	iFrameCtx.CSPConnectSrc = DefaultCSPConnectSrc
+	iFrameCtx.CSPConnectSrc = a.p.getConfiguration().CloudEnvironment().CSPConnectSrc
 	iFrameCtx.CSPScriptSrc = DefaultCSPScriptSrc
 	a.returnCSPHeaders(w, iFrameCtx)
 	w.Header().Set("Content-Type", "text/html")
@@ -449,7 +449,7 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 		return
 	}
 
-	parser := NewNotificationsParser(p.API, p.pluginStore, p.msteamsAppClient)
+	parser := NewNotificationsParser(p.API, p.pluginStore, p.msteamsAppClient, p.getConfiguration().CloudEnvironment().TeamsDomain)
 	if err := parser.ProcessPost(post); err != nil {
 		p.API.LogError("Failed to process mentions", "error", err.Error())
 		return

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -40,6 +40,10 @@ type validateTokenParams struct {
 	clientID            string
 }
 
+// jwksSetup builds the JWKS keyfunc for the given URL. It is a package variable
+// so tests can substitute a fake that avoids network access.
+var jwksSetup = setupJWKSet
+
 func setupJWKSet(jwksURL string) (keyfunc.Keyfunc, context.CancelFunc) {
 	// Setup JWK set to assist in verifying JWTs passed from Microsoft Teams.
 	ctx, cancelCtx := context.WithCancel(context.Background())

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	MicrosoftOnlineJWKSURL = "https://login.microsoftonline.com/common/discovery/v2.0/keys"
-	ExpectedAudienceFmt    = "api://%s/%s"
+	ExpectedAudienceFmt = "api://%s/%s"
 )
 
 type validationError struct {
@@ -41,13 +40,13 @@ type validateTokenParams struct {
 	clientID            string
 }
 
-func setupJWKSet() (keyfunc.Keyfunc, context.CancelFunc) {
+func setupJWKSet(jwksURL string) (keyfunc.Keyfunc, context.CancelFunc) {
 	// Setup JWK set to assist in verifying JWTs passed from Microsoft Teams.
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
-	k, err := keyfunc.NewDefaultCtx(ctx, []string{MicrosoftOnlineJWKSURL})
+	k, err := keyfunc.NewDefaultCtx(ctx, []string{jwksURL})
 	if err != nil {
-		logrus.WithError(err).WithField("jwks_url", MicrosoftOnlineJWKSURL).Error("Failed to create a keyfunc.Keyfunc - JWT authentication will not work")
+		logrus.WithError(err).WithField("jwks_url", jwksURL).Error("Failed to create a keyfunc.Keyfunc - JWT authentication will not work")
 		return nil, cancelCtx
 	}
 	logrus.Info("Started JWKS monitor")

--- a/server/mentions.go
+++ b/server/mentions.go
@@ -38,13 +38,15 @@ type NotificationsParser struct {
 	pluginStore      pluginstore.Store
 	Notifications    []*UserNotification
 	msteamsAppClient msteams.Client
+	teamsDomain      string
 }
 
-func NewNotificationsParser(api plugin.API, pluginStore pluginstore.Store, msteamsAppClient msteams.Client) *NotificationsParser {
+func NewNotificationsParser(api plugin.API, pluginStore pluginstore.Store, msteamsAppClient msteams.Client, teamsDomain string) *NotificationsParser {
 	return &NotificationsParser{
 		PAPI:             api,
 		pluginStore:      pluginStore,
 		msteamsAppClient: msteamsAppClient,
+		teamsDomain:      teamsDomain,
 	}
 }
 
@@ -318,7 +320,7 @@ func (p *NotificationsParser) sendUserActivity(userActivity *UserActivity) error
 
 	if err := p.msteamsAppClient.SendUserActivity(msteamsUserIDs, "mattermost_mention_with_name", message, url.URL{
 		Scheme:   "https",
-		Host:     "teams.microsoft.com",
+		Host:     p.teamsDomain,
 		Path:     "/l/entity/" + appID + "/notification_preview",
 		RawQuery: urlParams.Encode(),
 	}, map[string]string{

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -43,6 +43,7 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/users"
 	"golang.org/x/oauth2"
 
+	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
 	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/msteams/clientmodels"
 )
 
@@ -84,6 +85,7 @@ type ClientImpl struct {
 	token        *oauth2.Token
 	logService   *pluginapi.LogService
 	redirectURL  string
+	cloudEnv     cloudenv.Environment
 }
 
 type Activity struct {
@@ -204,9 +206,7 @@ func (at AccessToken) GetToken(_ context.Context, _ policy.TokenRequestOptions) 
 	}, nil
 }
 
-var TeamsDefaultScopes = []string{"https://graph.microsoft.com/.default"}
-
-func NewApp(tenantID, clientID, clientSecret string, logService *pluginapi.LogService) Client {
+func NewApp(cloudEnv cloudenv.Environment, tenantID, clientID, clientSecret string, logService *pluginapi.LogService) Client {
 	return &ClientImpl{
 		ctx:          context.Background(),
 		clientType:   "app",
@@ -214,6 +214,7 @@ func NewApp(tenantID, clientID, clientSecret string, logService *pluginapi.LogSe
 		clientID:     clientID,
 		clientSecret: clientSecret,
 		logService:   logService,
+		cloudEnv:     cloudEnv,
 	}
 }
 
@@ -225,10 +226,11 @@ func NewManualClient(tenantID, clientID string, logService *pluginapi.LogService
 		clientID:   clientID,
 		logService: logService,
 		client:     client,
+		cloudEnv:   cloudenv.EnvironmentFor(cloudenv.Commercial),
 	}
 }
 
-func NewTokenClient(redirectURL, tenantID, clientID, clientSecret string, token *oauth2.Token, logService *pluginapi.LogService) Client {
+func NewTokenClient(cloudEnv cloudenv.Environment, redirectURL, tenantID, clientID, clientSecret string, token *oauth2.Token, logService *pluginapi.LogService) Client {
 	client := &ClientImpl{
 		ctx:          context.Background(),
 		clientType:   "token",
@@ -238,15 +240,17 @@ func NewTokenClient(redirectURL, tenantID, clientID, clientSecret string, token 
 		token:        token,
 		logService:   logService,
 		redirectURL:  redirectURL,
+		cloudEnv:     cloudEnv,
 	}
 
+	scopes := []string{cloudEnv.GraphScope, "offline_access"}
 	conf := &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		Scopes:       append(TeamsDefaultScopes, "offline_access"),
+		Scopes:       scopes,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/authorize", tenantID),
-			TokenURL: fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID),
+			AuthURL:  fmt.Sprintf("https://%s/%s/oauth2/v2.0/authorize", cloudEnv.LoginAuthorityHost, tenantID),
+			TokenURL: fmt.Sprintf("https://%s/%s/oauth2/v2.0/token", cloudEnv.LoginAuthorityHost, tenantID),
 		},
 		RedirectURL: redirectURL,
 	}
@@ -255,7 +259,7 @@ func NewTokenClient(redirectURL, tenantID, clientID, clientSecret string, token 
 
 	accessToken := AccessToken{tokenSource: conf.TokenSource(context.Background(), client.token)}
 
-	auth, err := a.NewAzureIdentityAuthenticationProviderWithScopes(accessToken, append(TeamsDefaultScopes, "offline_access"))
+	auth, err := a.NewAzureIdentityAuthenticationProviderWithScopes(accessToken, scopes)
 	if err != nil {
 		logService.Error("Unable to create the client from the token", "error", err)
 		return nil
@@ -266,6 +270,7 @@ func NewTokenClient(redirectURL, tenantID, clientID, clientSecret string, token 
 		logService.Error("Unable to create the client from the token", "error", err)
 		return nil
 	}
+	adapter.SetBaseUrl(cloudEnv.GraphBaseURL)
 
 	client.client = msgraphsdk.NewGraphServiceClient(&ConcurrentGraphRequestAdapter{GraphRequestAdapter: *adapter})
 
@@ -276,10 +281,10 @@ func (tc *ClientImpl) RefreshToken(token *oauth2.Token) (*oauth2.Token, error) {
 	conf := &oauth2.Config{
 		ClientID:     tc.clientID,
 		ClientSecret: tc.clientSecret,
-		Scopes:       append(TeamsDefaultScopes, "offline_access"),
+		Scopes:       []string{tc.cloudEnv.GraphScope, "offline_access"},
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/authorize", tc.tenantID),
-			TokenURL: fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tc.tenantID),
+			AuthURL:  fmt.Sprintf("https://%s/%s/oauth2/v2.0/authorize", tc.cloudEnv.LoginAuthorityHost, tc.tenantID),
+			TokenURL: fmt.Sprintf("https://%s/%s/oauth2/v2.0/token", tc.cloudEnv.LoginAuthorityHost, tc.tenantID),
 		},
 		RedirectURL: tc.redirectURL,
 	}
@@ -329,6 +334,7 @@ func (tc *ClientImpl) Connect() error {
 			tc.clientSecret,
 			&azidentity.ClientSecretCredentialOptions{
 				ClientOptions: azcore.ClientOptions{
+					Cloud: tc.cloudEnv.AzureCloud,
 					Retry: policy.RetryOptions{
 						MaxRetries:    3,
 						RetryDelay:    4 * time.Second,
@@ -348,7 +354,7 @@ func (tc *ClientImpl) Connect() error {
 
 	httpClient := getHTTPClient()
 
-	auth, err := a.NewAzureIdentityAuthenticationProviderWithScopes(cred, append(TeamsDefaultScopes, "offline_access"))
+	auth, err := a.NewAzureIdentityAuthenticationProviderWithScopes(cred, []string{tc.cloudEnv.GraphScope, "offline_access"})
 	if err != nil {
 		return err
 	}
@@ -357,6 +363,7 @@ func (tc *ClientImpl) Connect() error {
 	if err != nil {
 		return err
 	}
+	adapter.SetBaseUrl(tc.cloudEnv.GraphBaseURL)
 
 	clientMutex.Lock()
 	defer clientMutex.Unlock()
@@ -1673,7 +1680,7 @@ func (tc *ClientImpl) CreateChat(chatType models.ChatType, userIDs []string) (*c
 		odataType := "#microsoft.graph.aadUserConversationMember"
 		conversationMember.SetOdataType(&odataType)
 		conversationMember.SetAdditionalData(map[string]any{
-			"user@odata.bind": "https://graph.microsoft.com/v1.0/users('" + userID + "')",
+			"user@odata.bind": tc.cloudEnv.GraphBaseURL + "/users('" + userID + "')",
 		})
 		conversationMember.SetRoles([]string{"owner"})
 
@@ -2179,14 +2186,14 @@ func (tc *ClientImpl) GetPresencesForUsers(userIDs []string) (map[string]clientm
 	return presences, nil
 }
 
-func GetAuthURL(redirectURL string, tenantID string, clientID string, clientSecret string, state string, codeVerifier string) string {
+func GetAuthURL(cloudEnv cloudenv.Environment, redirectURL string, tenantID string, clientID string, clientSecret string, state string, codeVerifier string) string {
 	conf := &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		Scopes:       append(TeamsDefaultScopes, "offline_access"),
+		Scopes:       []string{cloudEnv.GraphScope, "offline_access"},
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/authorize", tenantID),
-			TokenURL: fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantID),
+			AuthURL:  fmt.Sprintf("https://%s/%s/oauth2/v2.0/authorize", cloudEnv.LoginAuthorityHost, tenantID),
+			TokenURL: fmt.Sprintf("https://%s/%s/oauth2/v2.0/token", cloudEnv.LoginAuthorityHost, tenantID),
 		},
 		RedirectURL: redirectURL,
 	}

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -218,6 +218,11 @@ func NewApp(cloudEnv cloudenv.Environment, tenantID, clientID, clientSecret stri
 	}
 }
 
+// NewManualClient wraps a pre-built Graph client (the caller supplies the client
+// and therefore its endpoint), so the cloud environment here is only used for any
+// incidental cloud-derived values. It intentionally hardcodes the commercial
+// cloud: it has no in-repo callers today, so no national cloud is threaded in. If
+// it gains a caller for a gov tenant, thread the cloud environment through.
 func NewManualClient(tenantID, clientID string, logService *pluginapi.LogService, client *msgraphsdk.GraphServiceClient) Client {
 	return &ClientImpl{
 		ctx:        context.Background(),
@@ -230,6 +235,10 @@ func NewManualClient(tenantID, clientID string, logService *pluginapi.LogService
 	}
 }
 
+// NewTokenClient builds a delegated (user token) client. Its cloud wiring is
+// unverified: there are no in-repo callers of the delegated OAuth flow today, so
+// the per-cloud OAuth endpoints below have not been exercised end to end. Verify
+// against a gov tenant before relying on this path.
 func NewTokenClient(cloudEnv cloudenv.Environment, redirectURL, tenantID, clientID, clientSecret string, token *oauth2.Token, logService *pluginapi.LogService) Client {
 	client := &ClientImpl{
 		ctx:          context.Background(),
@@ -2190,6 +2199,9 @@ func (tc *ClientImpl) GetPresencesForUsers(userIDs []string) (map[string]clientm
 	return presences, nil
 }
 
+// GetAuthURL builds the delegated OAuth authorize URL. Like NewTokenClient, its
+// per-cloud wiring is unverified: there are no in-repo callers of the delegated
+// flow today, so verify against a gov tenant before relying on this path.
 func GetAuthURL(cloudEnv cloudenv.Environment, redirectURL string, tenantID string, clientID string, clientSecret string, state string, codeVerifier string) string {
 	conf := &oauth2.Config{
 		ClientID:     clientID,

--- a/server/msteams/client.go
+++ b/server/msteams/client.go
@@ -292,6 +292,10 @@ func (tc *ClientImpl) RefreshToken(token *oauth2.Token) (*oauth2.Token, error) {
 }
 
 func (tc *ClientImpl) GetApp(applicationID string) (*clientmodels.App, error) {
+	if tc.client == nil {
+		return nil, errors.New("MS Teams Graph client is not connected: verify the M365 tenant ID, client ID, and client secret are set in the plugin configuration")
+	}
+
 	application, err := tc.client.ApplicationsWithAppId(&applicationID).Get(tc.ctx, nil)
 	if err != nil {
 		return nil, err

--- a/server/msteams/client_test.go
+++ b/server/msteams/client_test.go
@@ -269,3 +269,13 @@ func TestCheckGroupChat(t *testing.T) {
 		assert.Nil(t, got)
 	})
 }
+
+func TestGetAppReturnsErrorWhenNotConnected(t *testing.T) {
+	// A client whose Connect() failed (or was never called) has a nil Graph
+	// client. GetApp must return an error rather than panicking on the nil
+	// dereference (regression guard for the credentials-check job crash).
+	c := &ClientImpl{}
+	app, err := c.GetApp("some-app-id")
+	assert.Nil(t, app)
+	assert.Error(t, err)
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -87,9 +87,14 @@ func (p *Plugin) OnActivate() error {
 		return errors.New("this plugin requires an enterprise license")
 	}
 
-	// Frame ancestors are configured in start() (which OnActivate invokes below
-	// and which also runs on every restart), so a national_cloud change refreshes
-	// them rather than leaving them frozen at first activation.
+	// Configure frame ancestors for the current cloud. This runs before
+	// pluginStore is set below so the resulting SaveConfig (which fires
+	// OnConfigurationChange) does not trigger a restart. A later national_cloud
+	// change is handled in OnConfigurationChange.
+	if err := p.updateFrameAncestors(); err != nil {
+		p.API.LogWarn("Failed to update frame ancestors", "error", err.Error())
+		// Continue activation even if this fails.
+	}
 
 	p.apiHandler = NewAPI(p)
 
@@ -228,14 +233,6 @@ func (p *Plugin) start(isRestart bool) {
 	// national_cloud setting switches to the new cloud's JWKS authority.
 	p.ensureJWKS()
 
-	// Keep the server's frame-ancestors in sync with the configured cloud. This
-	// runs on restarts too, so a national_cloud change adds the new cloud's
-	// embedding domains (see updateFrameAncestors for the union behavior).
-	if err := p.updateFrameAncestors(); err != nil {
-		p.API.LogWarn("Failed to update frame ancestors", "error", err.Error())
-		// Continue startup even if this fails.
-	}
-
 	// Initialize context for client reconnection
 	p.clientReconnectLock.Lock()
 	if p.clientReconnectCtx == nil {
@@ -369,6 +366,13 @@ func (p *Plugin) connectTeamsAppClient() error {
 	p.clientReconnectLock.Lock()
 	ctx := p.clientReconnectCtx
 	p.clientReconnectLock.Unlock()
+
+	// If the reconnection context is gone, the plugin is stopping (a concurrent
+	// stop() cleared it). Skip starting the goroutine rather than dereferencing a
+	// nil context in the select below.
+	if ctx == nil {
+		return nil
+	}
 
 	// Start a goroutine to periodically reconnect the client to refresh the token
 	go func(ctx context.Context) {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -197,6 +197,19 @@ func (p *Plugin) start(isRestart bool) {
 	}
 	p.clientReconnectLock.Unlock()
 
+	// Without M365 credentials there is nothing to connect to. This is the
+	// expected state for a freshly installed, not-yet-configured plugin, so we
+	// skip the connection (and the credentials check) rather than logging
+	// connection errors. A later OnConfigurationChange restarts the plugin once
+	// credentials are set. Only log on the initial start (not on restarts) to
+	// avoid duplicate messages, matching the JWKS setup guard above.
+	if !p.getConfiguration().isM365Configured() {
+		if !isRestart {
+			p.API.LogInfo("MS Teams integration is not configured yet; set the M365 tenant ID, client ID, and client secret in the System Console to enable it")
+		}
+		return
+	}
+
 	// connect to the Microsoft Teams API
 	err := p.connectTeamsAppClient()
 	if err != nil {
@@ -281,6 +294,11 @@ func (p *Plugin) connectTeamsAppClient() error {
 
 	err := p.msteamsAppClient.Connect()
 	if err != nil {
+		// Connect failed, so the client is only partially initialized (its
+		// internal Graph client is nil). Clear it so GetClientForApp reports
+		// no client rather than handing out an unusable one, and so a later
+		// attempt (for example after credentials are configured) retries.
+		p.msteamsAppClient = nil
 		p.API.LogError("Unable to connect to the app client", "error", err)
 		return err
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -22,7 +22,6 @@ import (
 const (
 	pluginID                = "com.mattermost.plugin-msteams-devsecops"
 	checkCredentialsJobName = "check_credentials" //#nosec G101 -- This is a false positive
-	allowedFrameAncestors   = "*.cloud.microsoft teams.microsoft.com *.teams.microsoft.com *.microsoft365.com *.office.com outlook.office.com outlook.office365.com outlook-sdf.office.com outlook-sdf.office365.com"
 )
 
 // Plugin implements the interface expected by the Mattermost server to communicate between the server and plugin processes.
@@ -122,8 +121,8 @@ func (p *Plugin) updateFrameAncestors() error {
 		currentAncestors = strings.Fields(currentAncestorsStr)
 	}
 
-	// Parse the allowed frame ancestors from our constant
-	allowedDomains := strings.Fields(allowedFrameAncestors)
+	// Parse the allowed frame ancestors for the configured national cloud.
+	allowedDomains := p.getConfiguration().CloudEnvironment().FrameAncestors
 
 	// Create a map to track unique domains and preserve existing ones
 	uniqueDomains := make(map[string]bool)
@@ -187,7 +186,7 @@ func (p *Plugin) start(isRestart bool) {
 	// set up JWK for verifying JWTs from Microsoft Teams
 	p.cancelKeyFuncLock.Lock()
 	if !isRestart && p.cancelKeyFunc == nil {
-		p.tabAppJWTKeyFunc, p.cancelKeyFunc = setupJWKSet()
+		p.tabAppJWTKeyFunc, p.cancelKeyFunc = setupJWKSet(p.getConfiguration().CloudEnvironment().JWKSURL)
 	}
 	p.cancelKeyFuncLock.Unlock()
 
@@ -273,6 +272,7 @@ func (p *Plugin) connectTeamsAppClient() error {
 	}
 
 	p.msteamsAppClient = msteams.NewApp(
+		p.getConfiguration().CloudEnvironment(),
 		p.getConfiguration().M365TenantID,
 		p.getConfiguration().M365ClientID,
 		p.getConfiguration().M365ClientSecret,

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -52,6 +52,10 @@ type Plugin struct {
 	tabAppJWTKeyFunc  keyfunc.Keyfunc
 	cancelKeyFunc     context.CancelFunc
 	cancelKeyFuncLock sync.Mutex
+	// activeJWKSURL is the JWKS URL the current tabAppJWTKeyFunc was built for.
+	// It is guarded by cancelKeyFuncLock and used to detect when a national_cloud
+	// change requires rebuilding the keyfunc against a different authority.
+	activeJWKSURL string
 
 	// checkCredentialsJob is a job that periodically checks credentials and permissions against the MS Graph API
 	checkCredentialsJob     *cluster.Job
@@ -83,11 +87,9 @@ func (p *Plugin) OnActivate() error {
 		return errors.New("this plugin requires an enterprise license")
 	}
 
-	// Update frame ancestors configuration
-	if err := p.updateFrameAncestors(); err != nil {
-		p.API.LogWarn("Failed to update frame ancestors", "error", err.Error())
-		// Continue activation even if this fails
-	}
+	// Frame ancestors are configured in start() (which OnActivate invokes below
+	// and which also runs on every restart), so a national_cloud change refreshes
+	// them rather than leaving them frozen at first activation.
 
 	p.apiHandler = NewAPI(p)
 
@@ -98,8 +100,18 @@ func (p *Plugin) OnActivate() error {
 	return nil
 }
 
-// updateFrameAncestors updates the ServiceSettings.FrameAncestors configuration
-// to include domains required by this plugin while preserving existing values.
+// updateFrameAncestors adds the configured national cloud's embedding domains to
+// ServiceSettings.FrameAncestors, preserving any existing values.
+//
+// This is intentionally union-only: it adds the current cloud's domains but does
+// not prune domains previously added for another cloud. ServiceSettings.FrameAncestors
+// is shared, server-wide configuration that administrators and other plugins may
+// also modify, and there is no reliable way to tell which entries this plugin
+// owns, so pruning risks removing domains that are legitimately configured. A
+// leftover domain from a previously selected cloud is a benign over-permission
+// (it only permits embedding in a Microsoft cloud the tenant is not using) and
+// does not affect the selected cloud, so the union approach is preferred over
+// risky removal.
 func (p *Plugin) updateFrameAncestors() error {
 	p.API.LogDebug("Updating frame ancestors configuration")
 
@@ -182,13 +194,47 @@ func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Req
 	p.apiHandler.ServeHTTP(w, r)
 }
 
-func (p *Plugin) start(isRestart bool) {
-	// set up JWK for verifying JWTs from Microsoft Teams
+// ensureJWKS makes sure the JWKS keyfunc used to verify Microsoft Teams JWTs
+// matches the JWKS authority of the configured national cloud. It builds the
+// keyfunc on first use and rebuilds it if the configured cloud's JWKS URL
+// changes (for example when national_cloud is switched from commercial to
+// gcchigh after the plugin was first activated on the commercial default). When
+// the URL is unchanged it does nothing, preserving the common no-change case.
+func (p *Plugin) ensureJWKS() {
+	jwksURL := p.getConfiguration().CloudEnvironment().JWKSURL
+
 	p.cancelKeyFuncLock.Lock()
-	if !isRestart && p.cancelKeyFunc == nil {
-		p.tabAppJWTKeyFunc, p.cancelKeyFunc = setupJWKSet(p.getConfiguration().CloudEnvironment().JWKSURL)
+	defer p.cancelKeyFuncLock.Unlock()
+
+	if p.cancelKeyFunc != nil && p.activeJWKSURL == jwksURL {
+		return
 	}
-	p.cancelKeyFuncLock.Unlock()
+
+	// Tear down the previous keyfunc (if any) before building the new one so we
+	// do not leak its background refresh goroutine.
+	if p.cancelKeyFunc != nil {
+		p.cancelKeyFunc()
+		p.cancelKeyFunc = nil
+		p.tabAppJWTKeyFunc = nil
+	}
+
+	p.tabAppJWTKeyFunc, p.cancelKeyFunc = jwksSetup(jwksURL)
+	p.activeJWKSURL = jwksURL
+}
+
+func (p *Plugin) start(isRestart bool) {
+	// Set up (or rebuild) the JWK set used to verify JWTs from Microsoft Teams.
+	// This runs on every start, including restarts, so that changing the
+	// national_cloud setting switches to the new cloud's JWKS authority.
+	p.ensureJWKS()
+
+	// Keep the server's frame-ancestors in sync with the configured cloud. This
+	// runs on restarts too, so a national_cloud change adds the new cloud's
+	// embedding domains (see updateFrameAncestors for the union behavior).
+	if err := p.updateFrameAncestors(); err != nil {
+		p.API.LogWarn("Failed to update frame ancestors", "error", err.Error())
+		// Continue startup even if this fails.
+	}
 
 	// Initialize context for client reconnection
 	p.clientReconnectLock.Lock()
@@ -265,6 +311,7 @@ func (p *Plugin) stop(isRestart bool) {
 			p.cancelKeyFunc()
 			p.cancelKeyFunc = nil
 		}
+		p.activeJWKSURL = ""
 		p.cancelKeyFuncLock.Unlock()
 	}
 }

--- a/server/plugin_lifecycle_test.go
+++ b/server/plugin_lifecycle_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MicahParks/keyfunc/v3"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
+)
+
+// TestCanaryTemporary is a temporary canary to prove package-main tests execute
+// in this harness (stdout is swallowed by mlog). It must be removed.
+func TestCanaryTemporary(t *testing.T) {
+	t.Fatal("canary: this failure proves the test ran")
+}
+
+// TestEnsureJWKSRebuildsOnCloudChange is the Issue 1 regression test: changing the
+// national_cloud setting must switch the JWKS URL the keyfunc validates against.
+// Before the fix the keyfunc was built once on first activation and never rebuilt
+// on a config change, so a gov tenant's tokens were validated against the
+// commercial JWKS and SSO broke.
+func TestEnsureJWKSRebuildsOnCloudChange(t *testing.T) {
+	var builtURLs []string
+	var cancels int
+
+	orig := jwksSetup
+	jwksSetup = func(url string) (keyfunc.Keyfunc, context.CancelFunc) {
+		builtURLs = append(builtURLs, url)
+		return nil, func() { cancels++ }
+	}
+	defer func() { jwksSetup = orig }()
+
+	commercialURL := cloudenv.EnvironmentFor(cloudenv.Commercial).JWKSURL
+	gccHighURL := cloudenv.EnvironmentFor(cloudenv.GCCHigh).JWKSURL
+	require.NotEqual(t, commercialURL, gccHighURL)
+
+	p := &Plugin{}
+
+	// First activation on the commercial default builds the keyfunc once.
+	p.setConfiguration(&configuration{NationalCloud: cloudenv.Commercial})
+	p.ensureJWKS()
+	assert.Equal(t, []string{commercialURL}, builtURLs)
+	assert.Equal(t, commercialURL, p.activeJWKSURL)
+	assert.Equal(t, 0, cancels)
+
+	// No cloud change: nothing is rebuilt.
+	p.ensureJWKS()
+	assert.Equal(t, []string{commercialURL}, builtURLs)
+	assert.Equal(t, 0, cancels)
+
+	// Switching to GCC High rebuilds against the gov JWKS and tears down the old.
+	p.setConfiguration(&configuration{NationalCloud: cloudenv.GCCHigh})
+	p.ensureJWKS()
+	assert.Equal(t, []string{commercialURL, gccHighURL}, builtURLs)
+	assert.Equal(t, gccHighURL, p.activeJWKSURL)
+	assert.Equal(t, 1, cancels)
+}
+
+// TestStartSkipsWhenUnconfigured verifies that starting the plugin without M365
+// credentials logs a single informational message and returns without connecting
+// or scheduling the credentials job (so an unconfigured install stays quiet and
+// does not panic).
+func TestStartSkipsWhenUnconfigured(t *testing.T) {
+	orig := jwksSetup
+	jwksSetup = func(string) (keyfunc.Keyfunc, context.CancelFunc) { return nil, func() {} }
+	defer func() { jwksSetup = orig }()
+
+	api := &plugintest.API{}
+	api.On("GetConfig").Return(&model.Config{})
+	api.On("SaveConfig", mock.Anything).Return(nil)
+	api.On("LogDebug", mock.Anything).Return().Maybe()
+	api.On("LogInfo", mock.Anything).Return()
+
+	p := &Plugin{}
+	p.API = api
+	p.client = pluginapi.NewClient(api, nil)
+	p.setConfiguration(&configuration{})
+
+	assert.NotPanics(t, func() { p.start(false) })
+
+	api.AssertCalled(t, "LogInfo", mock.Anything)
+	assert.Nil(t, p.GetClientForApp(), "no Teams client should be created when unconfigured")
+	api.AssertNotCalled(t, "LogError", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestConnectTeamsAppClientClearsClientOnFailure verifies that a failed Connect()
+// leaves no cached client, so GetClientForApp reports nil and the credentials
+// check skips cleanly instead of dereferencing a half-initialized client.
+func TestConnectTeamsAppClientClearsClientOnFailure(t *testing.T) {
+	api := &plugintest.API{}
+	api.On("LogError", mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+
+	p := &Plugin{}
+	p.API = api
+	p.client = pluginapi.NewClient(api, nil)
+	// Tenant and client ID set but secret empty, so Connect() fails building the
+	// client secret credential.
+	p.setConfiguration(&configuration{M365TenantID: "tenant", M365ClientID: "client"})
+
+	err := p.connectTeamsAppClient()
+	require.Error(t, err)
+	assert.Nil(t, p.GetClientForApp(), "client should be cleared after a failed Connect")
+}

--- a/server/plugin_lifecycle_test.go
+++ b/server/plugin_lifecycle_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/MicahParks/keyfunc/v3"
-	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/stretchr/testify/assert"
@@ -70,14 +69,10 @@ func TestStartSkipsWhenUnconfigured(t *testing.T) {
 	defer func() { jwksSetup = orig }()
 
 	api := &plugintest.API{}
-	api.On("GetConfig").Return(&model.Config{})
-	api.On("SaveConfig", mock.Anything).Return(nil)
-	api.On("LogDebug", mock.Anything).Return().Maybe()
 	api.On("LogInfo", mock.Anything).Return()
 
 	p := &Plugin{}
 	p.API = api
-	p.client = pluginapi.NewClient(api, nil)
 	p.setConfiguration(&configuration{})
 
 	assert.NotPanics(t, func() { p.start(false) })

--- a/server/plugin_lifecycle_test.go
+++ b/server/plugin_lifecycle_test.go
@@ -18,12 +18,6 @@ import (
 	"github.com/mattermost/mattermost-plugin-msteams-devsecops/server/cloudenv"
 )
 
-// TestCanaryTemporary is a temporary canary to prove package-main tests execute
-// in this harness (stdout is swallowed by mlog). It must be removed.
-func TestCanaryTemporary(t *testing.T) {
-	t.Fatal("canary: this failure proves the test ran")
-}
-
 // TestEnsureJWKSRebuildsOnCloudChange is the Issue 1 regression test: changing the
 // national_cloud setting must switch the JWKS URL the keyfunc validates against.
 // Before the fix the keyfunc was built once on first activation and never rebuilt


### PR DESCRIPTION
#### Summary

This PR implements Microsoft national cloud support so the plugin can run against US Government GCC High and DoD tenants, not just the commercial cloud. Previously every Microsoft endpoint (login authority, Graph, JWKS, and the iframe embedding domains) was hardcoded to the commercial cloud, so a GCC High or DoD tenant failed at authentication, token exchange, Graph API calls, and iframe embedding. GCC (moderate) already worked because it rides on the commercial endpoints; China (21Vianet) and air-gapped classified clouds are out of scope.

- Add a `server/cloudenv` package: a single per-cloud registry mapping each cloud (`commercial`, `gcchigh`, `dod`) to its login authority, Graph host/base URL/scope, JWKS URL, Azure SDK cloud config, Teams domain, portal host, frame-ancestors, and CSP connect-src. `cloud.AzureGovernment` selects `login.microsoftonline.us` for both GCC High and DoD but does not distinguish their Graph hosts (`graph.microsoft.us` vs `dod-graph.microsoft.us`), so the Graph base URL is set explicitly.
- Add a `national_cloud` plugin setting (`plugin.json` + `configuration.go`), defaulting to `commercial` so existing deployments are unchanged, and a matching `--cloud` flag on the `azure-setup` CLI.
- Wire the registry through the runtime: the `msteams` client OAuth/token URLs, Graph scope, `azidentity` credential cloud, Graph adapter base URL, and `odata.bind`; the JWKS URL (`jwt.go`); the CSP connect-src and frame-ancestors; and the activity notification host.
- Wire it through `azure-setup`: credential cloud on the option structs that support it, Graph scope, adapter base URL, and portal-host admin-consent links. The Azure CLI credential has no cloud option and inherits the operator's `az cloud set`.
- The generated Teams app manifest and the Teams JS SDK CDN are intentionally unchanged: the manifest is already templated from the Mattermost `SiteURL`, and the SDK is served from the same `res.cdn.office.net` across clouds. Graph permission matching is by GUID, so the `graph.microsoft.com` display-name strings in `credentials.go` need no change.
- A `cloudenv` test asserts the commercial output is byte-identical to the previously hardcoded values to guard against regressions. The gov Outlook/M365 frame-ancestor domains are best-effort and flagged in code for verification against a real gov tenant.

Also fixes an unrelated crash surfaced during testing: installing the plugin without M365 credentials configured logged connection errors and triggered a nil pointer panic in the credentials-check job. The plugin now skips connecting (and the credentials check) until the tenant ID, client ID, and client secret are all set, logs a single informational message instead of errors, clears the cached client when `Connect()` fails, and guards `GetApp` against a nil Graph client.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69380

#### Release Note

```release-note
Added support for deploying the plugin in Microsoft national clouds (US Government GCC High and DoD) via a new National Cloud setting and a matching azure-setup --cloud flag. Defaults to the commercial cloud, so existing deployments are unaffected.
```
